### PR TITLE
Add EU cookie banner to Nexum Get Started

### DIFF
--- a/Aurora/public/nexum.css
+++ b/Aurora/public/nexum.css
@@ -513,3 +513,27 @@ a:hover {
   border-color: var(--accent-light);
   color: #fff;
 }
+
+/* Cookie consent banner */
+#cookieBanner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-alt);
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border);
+  display: none;
+  z-index: 1000;
+  text-align: center;
+}
+
+#cookieBanner button {
+  margin-left: 1rem;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+}

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -1108,8 +1108,21 @@
         if(sb.style.display === 'none') sb.style.display = '';
         else sb.style.display = 'none';
       });
+
+      const banner = document.getElementById('cookieBanner');
+      if(banner){
+        if(!localStorage.getItem('cookieAccepted')) banner.style.display = 'block';
+        document.getElementById('cookieAcceptBtn').addEventListener('click', () => {
+          localStorage.setItem('cookieAccepted', 'yes');
+          banner.style.display = 'none';
+        });
+      }
     });
 
   </script>
+  <div id="cookieBanner">
+    This site uses cookies to enhance your experience.
+    <button id="cookieAcceptBtn">Accept</button>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add cookie consent banner styles
- display banner in Nexum UI and store acceptance in localStorage

## Testing
- `npm test` *(fails: could not find package.json)*