### PR TITLE
Rename pipeline page

### DIFF
--- a/Aurora/public/ImagePipeline.html
+++ b/Aurora/public/ImagePipeline.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body style="padding:1rem;">
-<!--  <h2>PrintifyPipeline</h2>-->
+<!--  <h2>ImagePipeline</h2>-->
   <h2>Image Design Pipeline</h2>
   <div id="errorMessage" style="color:red;margin-bottom:0.5rem;"></div>
   <ul id="stageList"></ul>
@@ -296,7 +296,7 @@
           errorEl.textContent = `Error fetching file for ID ${idParam}`;
         }
       }
-      console.debug('Loaded PrintifyPipeline for file =>', file);
+      console.debug('Loaded ImagePipeline for file =>', file);
       if (file) {
       upscaleBtn.addEventListener('click', async () => {
         console.debug('Submit to Upscale clicked with file =>', file);

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2245,7 +2245,7 @@ function renderFileList(){
     const openBtn = document.createElement("button");
     openBtn.textContent = "Open";
     openBtn.addEventListener("click", () => {
-      window.open(`PrintifyPipeline.html?file=${encodeURIComponent(f.name)}`,
+      window.open(`ImagePipeline.html?file=${encodeURIComponent(f.name)}`,
                   "_blank");
     });
     tdAction.appendChild(openBtn);

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -113,7 +113,7 @@
           const tr = document.createElement('tr');
           const jobLink = job.jobId ? `<a href="jobs.html?jobId=${job.jobId}" target="_blank">${job.jobId}</a>` : '';
           const dbLink = job.dbId
-            ? `<a href="PrintifyPipeline.html?file=${encodeURIComponent(job.file)}" target="_blank">${job.dbId}</a>`
+            ? `<a href="ImagePipeline.html?file=${encodeURIComponent(job.file)}" target="_blank">${job.dbId}</a>`
             : '';
           tr.innerHTML = `
             <td>${job.id}</td>

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2030,10 +2030,10 @@ app.post("/api/image/generate", async (req, res) => {
   }
 });
 
-// Verbose logging for PrintifyPipeline page
-app.get("/PrintifyPipeline.html", (req, res) => {
-  console.debug("[Server Debug] GET /PrintifyPipeline.html =>", JSON.stringify(req.query));
-  res.sendFile(path.join(__dirname, "../public/PrintifyPipeline.html"));
+// Verbose logging for ImagePipeline page
+app.get("/ImagePipeline.html", (req, res) => {
+  console.debug("[Server Debug] GET /ImagePipeline.html =>", JSON.stringify(req.query));
+  res.sendFile(path.join(__dirname, "../public/ImagePipeline.html"));
 });
 
 app.use(express.static(path.join(__dirname, "../public")));


### PR DESCRIPTION
## Summary
- rename `PrintifyPipeline.html` to `ImagePipeline.html`
- update server route and JS/HTML references

## Testing
- `npm run lint` in `Aurora`
- `npm test` (fails: no test script)
- `npm run lint` (missing script)
- `npm test` in VMRunner (fails: no test specified)
- `npm run lint` in VMRunner (missing script)
- `npm test` in Sterling (missing script)
- `npm run lint` in Sterling (missing script)
- `npm test` in stirfry (missing script)
- `npm run lint` in stirfry (missing script)
