### PR TITLE
Enable image replies only for design tabs

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1895,6 +1895,13 @@ app.post("/api/image/generate", async (req, res) => {
       return res.status(400).json({ error: "Missing prompt" });
     }
 
+    if (tabId) {
+      const tab = db.getChatTab(parseInt(tabId, 10));
+      if (tab && tab.tab_type !== 'design') {
+        return res.status(400).json({ error: 'Image generation only allowed for design tabs' });
+      }
+    }
+
     const service = (provider || db.getSetting("image_gen_service") || "openai").toLowerCase();
 
     const allowedSizes = ["1024x1024", "1024x1792", "1792x1024"];

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -627,12 +627,14 @@ export default class TaskDB {
 
   createChatTab(name, nexum = 0, project = '', repo = '', type = 'chat') {
     const ts = new Date().toISOString();
+    const genImages = type === 'design' ? 1 : 0;
     const { lastInsertRowid } = this.db.prepare(`
       INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, tab_type)
-      VALUES (@name, @created_at, 1, @nexum, @project_name, @repo_ssh_url, @tab_type)
+      VALUES (@name, @created_at, @generate_images, @nexum, @project_name, @repo_ssh_url, @tab_type)
     `).run({
       name,
       created_at: ts,
+      generate_images: genImages,
       nexum: nexum ? 1 : 0,
       project_name: project,
       repo_ssh_url: repo,
@@ -683,9 +685,10 @@ export default class TaskDB {
   }
 
   setChatTabConfig(tabId, project = '', repo = '', type = 'chat') {
+    const genImages = type === 'design' ? 1 : 0;
     this.db.prepare(
-        "UPDATE chat_tabs SET project_name=?, repo_ssh_url=?, tab_type=? WHERE id=?"
-    ).run(project, repo, type, tabId);
+        "UPDATE chat_tabs SET project_name=?, repo_ssh_url=?, tab_type=?, generate_images=? WHERE id=?"
+    ).run(project, repo, type, genImages, tabId);
   }
 
   getChatTab(tabId) {


### PR DESCRIPTION
## Summary
- restrict automatic image generation to design tabs only
- disable `Generate images for replies` toggle for chat tabs
- enforce design-tab requirement on the backend

## Testing
- `npm run lint`