### PR TITLE
Associate chats with session

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1073,7 +1073,7 @@ async function addNewTab(){
   const r = await fetch("/api/chat/tabs/new", {
     method:"POST",
     headers:{"Content-Type":"application/json"},
-    body: JSON.stringify({ name, nexum: 0, project: projectInput })
+    body: JSON.stringify({ name, nexum: 0, project: projectInput, sessionId })
   });
   if(r.ok){
     hideModal($("#newTabModal"));
@@ -1632,7 +1632,7 @@ chatSendBtnEl.addEventListener("click", async () => {
     const resp = await fetch("/api/chat",{
       method:"POST",
       headers:{"Content-Type":"application/json"},
-      body:JSON.stringify({message:combinedUserText, tabId: currentTabId, userTime})
+      body:JSON.stringify({message:combinedUserText, tabId: currentTabId, userTime, sessionId})
     });
     clearInterval(waitInterval);
     waitingElem.textContent = "";
@@ -2753,7 +2753,7 @@ btnNexumTabs?.addEventListener("click", () => { window.location.href = btnNexumT
       await fetch("/api/chat/tabs/new", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "Main", nexum: 0 })
+        body: JSON.stringify({ name: "Main", nexum: 0, sessionId })
       });
       await loadTabs();
       const firstActive = chatTabs.find(t => !t.archived);
@@ -3956,7 +3956,7 @@ registerActionHook("generateImage", async ({response}) => {
     const r = await fetch('/api/image/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt, tabId: currentTabId, provider: imageGenService })
+      body: JSON.stringify({ prompt, tabId: currentTabId, provider: imageGenService, sessionId })
     });
     if(genIndicator) genIndicator.style.display = "none";
     const data = await r.json();

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -635,7 +635,7 @@
       const type = newTabSelectedType;
       const message = document.getElementById('newTabChatInput').value.trim();
       const repo = document.getElementById('newTabRepoInput').value.trim();
-      const body = { name:'New Tab', nexum:1, type, project:'', repo };
+      const body = { name:'New Tab', nexum:1, type, project:'', repo, sessionId };
       const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
       if(r.ok){
         const data = await r.json();
@@ -662,7 +662,7 @@
       const type = startSelectedType;
       const message = document.getElementById('startChatInput').value.trim();
       const repo = document.getElementById('startRepoInput').value.trim();
-      const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo };
+      const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo, sessionId };
       const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
       if(r.ok){
         const data = await r.json();
@@ -834,7 +834,7 @@
       document.getElementById('chat').appendChild(aiEl);
       document.getElementById('chat').scrollTop=document.getElementById('chat').scrollHeight;
       try{
-        const resp=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text,tabId:currentTabId})});
+        const resp=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text,tabId:currentTabId,sessionId})});
         if(!resp.ok||!resp.body){aiEl.textContent='[error]';return;}
         const reader=resp.body.getReader();
         const dec=new TextDecoder();
@@ -875,7 +875,7 @@
       document.getElementById('chat').appendChild(aiEl);
       document.getElementById('chat').scrollTop=document.getElementById('chat').scrollHeight;
       try{
-        const resp=await fetch('/api/image/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt:text, tabId:currentTabId})});
+        const resp=await fetch('/api/image/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt:text, tabId:currentTabId, sessionId})});
         const data=await resp.json();
         if(resp.ok && data.url){
           aiEl.textContent='';

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1048,6 +1048,7 @@ app.post("/api/chat", async (req, res) => {
   try {
     const userMessage = req.body.message || "";
     const chatTabId = req.body.tabId || 1;
+    const sessionId = req.body.sessionId || "";
     const userTime = req.body.userTime || new Date().toISOString();
 
     if (!userMessage) {
@@ -1071,7 +1072,7 @@ app.post("/api/chat", async (req, res) => {
       }
     }
 
-    const chatPairId = db.createChatPair(userMessage, chatTabId, systemContext);
+    const chatPairId = db.createChatPair(userMessage, chatTabId, systemContext, sessionId);
     conversation.push({ role: "user", content: userMessage });
     db.logActivity("User chat", JSON.stringify({ tabId: chatTabId, message: userMessage, userTime }));
 
@@ -1278,6 +1279,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
     const project = req.body.project || '';
     const repo = req.body.repo || '';
     const type = req.body.type || 'chat';
+    const sessionId = req.body.sessionId || '';
 
     const autoNaming = db.getSetting("chat_tab_auto_naming");
     const projectName = db.getSetting("sterling_project") || "";
@@ -1285,7 +1287,7 @@ app.post("/api/chat/tabs/new", (req, res) => {
       name = `${projectName}: ${name}`;
     }
 
-    const tabId = db.createChatTab(name, nexum, project, repo, type);
+    const tabId = db.createChatTab(name, nexum, project, repo, type, sessionId);
     res.json({ success: true, id: tabId });
   } catch (err) {
     console.error("[TaskQueue] POST /api/chat/tabs/new error:", err);
@@ -1890,7 +1892,7 @@ app.get("/api/upscale/result", (req, res) => {
 // Generate an image using OpenAI's image API.
 app.post("/api/image/generate", async (req, res) => {
   try {
-    const { prompt, n, size, model, provider, tabId } = req.body || {};
+    const { prompt, n, size, model, provider, tabId, sessionId = '' } = req.body || {};
     if (!prompt) {
       return res.status(400).json({ error: "Missing prompt" });
     }
@@ -1928,7 +1930,7 @@ app.post("/api/image/generate", async (req, res) => {
       );
       const tab = parseInt(tabId, 10) || 1;
       const imageTitle = await deriveImageTitle(prompt);
-      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated');
+      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId);
       return res.json({ success: true, url: localUrl, title: imageTitle });
     }
 
@@ -2012,7 +2014,7 @@ app.post("/api/image/generate", async (req, res) => {
 
     const tab = parseInt(tabId, 10) || 1;
     const imageTitle = await deriveImageTitle(prompt, openaiClient);
-    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated');
+    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId);
 
     res.json({ success: true, url: localUrl, title: imageTitle });
   } catch (err) {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -88,7 +88,8 @@ export default class TaskDB {
                                              nexum INTEGER DEFAULT 0,
                                              project_name TEXT DEFAULT '',
                                              repo_ssh_url TEXT DEFAULT '',
-                                             tab_type TEXT DEFAULT 'chat'
+                                             tab_type TEXT DEFAULT 'chat',
+                                             session_id TEXT DEFAULT ''
       );
     `);
     try {
@@ -127,6 +128,12 @@ export default class TaskDB {
     } catch(e) {
       //console.debug("[TaskDB Debug] chat_tabs.tab_type column exists, skipping.", e.message);
     }
+    try {
+      this.db.exec("ALTER TABLE chat_tabs ADD COLUMN session_id TEXT DEFAULT '';" );
+      console.debug("[TaskDB Debug] Added chat_tabs.session_id column");
+    } catch(e) {
+      //console.debug("[TaskDB Debug] chat_tabs.session_id column exists, skipping.", e.message);
+    }
 
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS chat_pairs (
@@ -142,7 +149,8 @@ export default class TaskDB {
                                               image_url TEXT,
                                               image_alt TEXT DEFAULT '',
                                               image_title TEXT DEFAULT '',
-                                              image_status TEXT DEFAULT ''
+                                              image_status TEXT DEFAULT '',
+                                              session_id TEXT DEFAULT ''
       );
     `);
 
@@ -199,6 +207,12 @@ export default class TaskDB {
       console.debug("[TaskDB Debug] Added chat_pairs.image_status column");
     } catch(e) {
       //console.debug("[TaskDB Debug] image_status column exists, skipping.", e.message);
+    }
+    try {
+      this.db.exec(`ALTER TABLE chat_pairs ADD COLUMN session_id TEXT DEFAULT '';`);
+      console.debug("[TaskDB Debug] Added chat_pairs.session_id column");
+    } catch(e) {
+      //console.debug("[TaskDB Debug] chat_pairs.session_id column exists, skipping.", e.message);
     }
 
     this.db.exec(`
@@ -552,24 +566,25 @@ export default class TaskDB {
         .run(message, type, new Date().toISOString());
   }
 
-  createChatPair(userText, chatTabId = 1, systemContext = "") {
+  createChatPair(userText, chatTabId = 1, systemContext = "", sessionId = "") {
     const timestamp = new Date().toISOString();
     const { lastInsertRowid } = this.db.prepare(`
       INSERT INTO chat_pairs (
         user_text, ai_text, model, timestamp, ai_timestamp,
         chat_tab_id, system_context, token_info,
-        image_url, image_alt, image_title
+        image_url, image_alt, image_title, image_status, session_id
       )
       VALUES (
         @user_text, '', '', @timestamp, NULL,
         @chat_tab_id, @system_context, NULL,
-        NULL, '', ''
+        NULL, '', '', '', @session_id
       )
     `).run({
       user_text: userText,
       timestamp,
       chat_tab_id: chatTabId,
-      system_context: systemContext
+      system_context: systemContext,
+      session_id: sessionId
     });
     return lastInsertRowid;
   }
@@ -591,15 +606,15 @@ export default class TaskDB {
     });
   }
 
-  createImagePair(url, altText = '', chatTabId = 1, title = '', status = 'Generated') {
+  createImagePair(url, altText = '', chatTabId = 1, title = '', status = 'Generated', sessionId = '') {
     const ts = new Date().toISOString();
     const { lastInsertRowid } = this.db.prepare(`
       INSERT INTO chat_pairs (
         user_text, ai_text, model, timestamp, ai_timestamp,
         chat_tab_id, system_context, token_info,
-        image_url, image_alt, image_title, image_status
-      ) VALUES ('', '', '', @ts, @ts, @chat_tab_id, '', NULL, @url, @alt, @title, @status)
-    `).run({ ts, chat_tab_id: chatTabId, url, alt: altText, title, status });
+        image_url, image_alt, image_title, image_status, session_id
+      ) VALUES ('', '', '', @ts, @ts, @chat_tab_id, '', NULL, @url, @alt, @title, @status, @session_id)
+    `).run({ ts, chat_tab_id: chatTabId, url, alt: altText, title, status, session_id: sessionId });
     return lastInsertRowid;
   }
 
@@ -625,18 +640,19 @@ export default class TaskDB {
         .get(id);
   }
 
-  createChatTab(name, nexum = 0, project = '', repo = '', type = 'chat') {
+  createChatTab(name, nexum = 0, project = '', repo = '', type = 'chat', sessionId = '') {
     const ts = new Date().toISOString();
     const { lastInsertRowid } = this.db.prepare(`
-      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, tab_type)
-      VALUES (@name, @created_at, 1, @nexum, @project_name, @repo_ssh_url, @tab_type)
+      INSERT INTO chat_tabs (name, created_at, generate_images, nexum, project_name, repo_ssh_url, tab_type, session_id)
+      VALUES (@name, @created_at, 1, @nexum, @project_name, @repo_ssh_url, @tab_type, @session_id)
     `).run({
       name,
       created_at: ts,
       nexum: nexum ? 1 : 0,
       project_name: project,
       repo_ssh_url: repo,
-      tab_type: type
+      tab_type: type,
+      session_id: sessionId
     });
     return lastInsertRowid;
   }


### PR DESCRIPTION
## Summary
- associate session_id with chat_tabs and chat_pairs tables
- propagate session_id through API to server and database
- include sessionId when creating chat tabs, chat pairs and generated images

## Testing
- `npm run lint`
