### PR TITLE
Link chat data to session

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1081,7 +1081,7 @@ async function addNewTab(){
   const r = await fetch("/api/chat/tabs/new", {
     method:"POST",
     headers:{"Content-Type":"application/json"},
-    body: JSON.stringify({ name, nexum: 0, project: projectInput, type: tabType })
+    body: JSON.stringify({ name, nexum: 0, project: projectInput, type: tabType, sessionId })
   });
   if(r.ok){
     hideModal($("#newTabModal"));
@@ -1657,7 +1657,7 @@ chatSendBtnEl.addEventListener("click", async () => {
     const resp = await fetch("/api/chat",{
       method:"POST",
       headers:{"Content-Type":"application/json"},
-      body:JSON.stringify({message:combinedUserText, tabId: currentTabId, userTime})
+      body:JSON.stringify({message:combinedUserText, tabId: currentTabId, userTime, sessionId})
     });
     clearInterval(waitInterval);
     waitingElem.textContent = "";
@@ -2779,7 +2779,7 @@ btnNexumTabs?.addEventListener("click", () => { window.location.href = btnNexumT
       await fetch("/api/chat/tabs/new", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "Main", nexum: 0 })
+        body: JSON.stringify({ name: "Main", nexum: 0, sessionId })
       });
       await loadTabs();
       const firstActive = chatTabs.find(t => !t.archived);
@@ -3986,7 +3986,7 @@ registerActionHook("generateImage", async ({response}) => {
     const r = await fetch('/api/image/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ prompt, tabId: currentTabId, provider: imageGenService })
+      body: JSON.stringify({ prompt, tabId: currentTabId, provider: imageGenService, sessionId })
     });
     if(genIndicator) genIndicator.style.display = "none";
     const data = await r.json();

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -627,7 +627,7 @@
       const type = newTabSelectedType;
       const message = document.getElementById('newTabChatInput').value.trim();
       const repo = document.getElementById('newTabRepoInput').value.trim();
-      const body = { name:'New Tab', nexum:1, type, project:'', repo };
+      const body = { name:'New Tab', nexum:1, type, project:'', repo, sessionId };
       const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
       if(r.ok){
         const data = await r.json();
@@ -651,7 +651,7 @@
     async function createStartTab(type){
       const repoEl = document.getElementById('startRepoInput');
       const repo = repoEl ? repoEl.value.trim() : '';
-      const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo };
+      const body = { name:'New Tab', nexum: startInAurora ? 0 : 1, type, project:'', repo, sessionId };
       const r = await fetch('/api/chat/tabs/new',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
       if(r.ok){
         const data = await r.json();
@@ -814,7 +814,7 @@
       document.getElementById('chat').appendChild(aiEl);
       document.getElementById('chat').scrollTop=document.getElementById('chat').scrollHeight;
       try{
-        const resp=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text,tabId:currentTabId})});
+        const resp=await fetch('/api/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text,tabId:currentTabId,sessionId})});
         if(!resp.ok||!resp.body){aiEl.textContent='[error]';return;}
         const reader=resp.body.getReader();
         const dec=new TextDecoder();
@@ -855,7 +855,7 @@
       document.getElementById('chat').appendChild(aiEl);
       document.getElementById('chat').scrollTop=document.getElementById('chat').scrollHeight;
       try{
-        const resp=await fetch('/api/image/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt:text, tabId:currentTabId})});
+        const resp=await fetch('/api/image/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({prompt:text, tabId:currentTabId, sessionId})});
         const data=await resp.json();
         if(resp.ok && data.url){
           aiEl.textContent='';


### PR DESCRIPTION
## Summary
- add `session_id` to `chat_tabs` and `chat_pairs` database tables
- send sessionId when creating tabs, chat pairs and images
- store sessionId in server when handling chat and image APIs

## Testing
- `npm run lint`