### PR TITLE
Implement per-session image generation limit

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1897,6 +1897,12 @@ app.post("/api/image/generate", async (req, res) => {
       return res.status(400).json({ error: "Missing prompt" });
     }
 
+    if (sessionId && db.countImagesForSession(sessionId) >= 10) {
+      return res
+        .status(429)
+        .json({ error: "Image generation limit reached for this session" });
+    }
+
     if (tabId) {
       const tab = db.getChatTab(parseInt(tabId, 10));
       if (tab && tab.tab_type !== 'design') {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -823,6 +823,13 @@ export default class TaskDB {
     return row ? row.id : null;
   }
 
+  countImagesForSession(sessionId) {
+    const row = this.db
+        .prepare("SELECT COUNT(*) AS cnt FROM chat_pairs WHERE session_id=? AND image_url IS NOT NULL")
+        .get(sessionId);
+    return row ? row.cnt : 0;
+  }
+
   setImageStatus(url, status) {
     const stmt = this.db.prepare("UPDATE chat_pairs SET image_status=? WHERE image_url=?");
     const info = stmt.run(status, url);


### PR DESCRIPTION
## Summary
- cap image generation at 10 per session ID
- expose a helper to count images per session

## Testing
- `npm test` *(fails: missing package.json)*
- `npm test` in Aurora *(fails: missing script)*
- `npm test` in Sterling *(fails: missing script)*
- `npm test` in VMRunner *(fails: "Error: no test specified")*