### PR TITLE
Display session image limit

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -20,6 +20,7 @@
     <img id="sidebarToggleIcon" class="sidebar-toggle-icon" src="alfe_favicon_clean_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <div id="versionInfo" class="version-info" style="margin-bottom: 5px;">Alfe AI beta-2.30 <a href="about.html" target="_blank" style="color: cyan">about</a></div>
     <span id="sessionIdText" class="session-id"></span>
+    <span id="imageLimitInfo" class="session-limit"></span>
     <div id="navSpinner" style="text-align:center; margin-top:1rem;"><span class="loading-spinner"></span></div>
     <ul id="navSkeletonList" style="list-style:none;padding:0 1rem;display:none;">
       <li class="nav-placeholder"></li>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4,6 +4,7 @@ sessionStorage.setItem('sessionId', sessionId);
 document.addEventListener('DOMContentLoaded', () => {
   const sessEl = document.getElementById('sessionIdText');
   if (sessEl) sessEl.textContent = sessionId;
+  updateImageLimitInfo();
 });
 
 let columnsOrder = [
@@ -122,6 +123,21 @@ function showToast(msg, duration=1500){
   el.textContent = msg;
   el.classList.add("show");
   setTimeout(() => el.classList.remove("show"), duration);
+}
+
+async function updateImageLimitInfo(files){
+  try {
+    let data = files;
+    if(!data){
+      const resp = await fetch(`/api/upload/list?sessionId=${encodeURIComponent(sessionId)}`);
+      data = await resp.json();
+    }
+    const count = data.filter(f => f.source === 'Generated').length;
+    const el = document.getElementById('imageLimitInfo');
+    if(el) el.textContent = `Images: ${count}/10`;
+  } catch(e){
+    console.error('Failed to update image limit info:', e);
+  }
 }
 
 function registerActionHook(name, fn){
@@ -2311,6 +2327,7 @@ async function loadFileList() {
     fileListData = await fetch(`/api/upload/list?sessionId=${encodeURIComponent(sessionId)}`).then(r => r.json());
     sortFileData();
     renderFileList();
+    updateImageLimitInfo(fileListData);
   } catch(e) {
     console.error("Error fetching file list:", e);
   }
@@ -3992,6 +4009,7 @@ registerActionHook("generateImage", async ({response}) => {
     const data = await r.json();
     if(r.ok && data.url){
       addImageChatBubble(data.url, prompt, data.title || "");
+      updateImageLimitInfo();
       if(imageLoopEnabled){
         setTimeout(runImageLoop, 0);
       }

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -524,6 +524,16 @@ body {
   user-select: text;
 }
 
+/* Display current session image count under the ID */
+#imageLimitInfo.session-limit {
+  position: absolute;
+  top: 32px;
+  left: 60px;
+  font-size: 0.75rem;
+  color: #aaa;
+  z-index: 1000;
+}
+
 /* Token count indicator in bottom-right corner of subbubble */
 .token-indicator {
   position: absolute;


### PR DESCRIPTION
## Summary
- show current session image quota under session ID
- style the image limit indicator
- update image count on page load, file list refresh, and after image generation

## Testing
- `npm run lint`