### PR TITLE
Improve image limit display

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -135,7 +135,14 @@ async function updateImageLimitInfo(files){
     }
     const count = data.filter(f => f.source === 'Generated').length;
     const el = document.getElementById('imageLimitInfo');
-    if(el) el.textContent = `Images: ${count}/10`;
+    if(el) {
+      el.textContent = `Images: ${count}/10`;
+      if(count >= 10) {
+        el.classList.add('limit-reached');
+      } else {
+        el.classList.remove('limit-reached');
+      }
+    }
   } catch(e){
     console.error('Failed to update image limit info:', e);
   }

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -534,6 +534,35 @@ body {
   z-index: 1000;
 }
 
+# When the image generation limit is reached (10/10),
+# highlight the info text in dark red for visibility
+# by applying a new "limit-reached" class via JavaScript.
+# This class is added dynamically when the count hits the limit.
+# The base class `session-limit` keeps default styling.
+# We add the color rule separately so it overrides the default.
+# This ensures normal color is used until the limit is hit.
+#
+# Example HTML after update:
+#   <span id="imageLimitInfo" class="session-limit limit-reached">Images: 10/10</span>
+#
+# The dark red color uses the named color `darkred` for clarity.
+# It roughly corresponds to #8B0000.
+#
+# This rule must follow the base styling to take precedence.
+# See main.js for the logic that toggles this class.
+#
+# Added per user request to visually indicate when the
+# generation limit has been fully consumed.
+#
+# The instructions in AGENTS.md mention nothing about CSS color,
+# so we implement as straightforwardly as possible.
+#
+# Additional comments for maintainers: none.
+
+#imageLimitInfo.session-limit.limit-reached {
+  color: darkred;
+}
+
 /* Token count indicator in bottom-right corner of subbubble */
 .token-indicator {
   position: absolute;


### PR DESCRIPTION
## Summary
- highlight image generation limit when reached
- update JS to toggle limit styling

## Testing
- `npm run lint --prefix Aurora`
- `npm run lint --prefix Sterling` *(fails: Missing script)*