### PR TITLE
Persist session ID via cookie

### DIFF
--- a/Aurora/public/PrintifyPipeline.html
+++ b/Aurora/public/PrintifyPipeline.html
@@ -46,9 +46,8 @@
     <button id="printifyButton" hidden>Submit to Printify</button>
   </div>
   <pre id="upscaleTerminal" style="background:#000;color:#0f0;padding:0.5rem;margin-top:0.5rem;height:200px;overflow:auto;font-family:monospace;"></pre>
+  <script src="session.js"></script>
   <script>
-    const sessionId = sessionStorage.getItem('sessionId') || crypto.randomUUID();
-    sessionStorage.setItem('sessionId', sessionId);
 
     const params = new URLSearchParams(window.location.search);
     let file = params.get('file');

--- a/Aurora/public/generated_images.html
+++ b/Aurora/public/generated_images.html
@@ -26,9 +26,8 @@
 <body>
   <h1>Generated Images</h1>
   <div id="grid" class="grid"></div>
+  <script src="session.js"></script>
   <script>
-    const sessionId = sessionStorage.getItem('sessionId') || crypto.randomUUID();
-    sessionStorage.setItem('sessionId', sessionId);
     async function loadImages(){
       try {
         const resp = await fetch('/api/upload/list?sessionId=' + encodeURIComponent(sessionId));

--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -618,6 +618,7 @@
   </div>
 </div>
 <div id="toast" class="toast"></div>
+<script src="session.js"></script>
 <script src="main.js"></script>
 </body>
 </html>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1,6 +1,7 @@
-// Generate or retrieve a unique session ID stored in sessionStorage
-const sessionId = sessionStorage.getItem('sessionId') || crypto.randomUUID();
-sessionStorage.setItem('sessionId', sessionId);
+// Generate or retrieve a unique session ID stored in cookie/sessionStorage
+const sessionId = typeof getSessionId === 'function'
+  ? getSessionId()
+  : (sessionStorage.getItem('sessionId') || crypto.randomUUID());
 document.addEventListener('DOMContentLoaded', () => {
   const sessEl = document.getElementById('sessionIdText');
   if (sessEl) sessEl.textContent = sessionId;

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -230,10 +230,8 @@
       </div>
     </div>
   </div>
+  <script src="session.js"></script>
   <script>
-    // Generate or retrieve a unique session ID stored in sessionStorage
-    const sessionId = sessionStorage.getItem('sessionId') || crypto.randomUUID();
-    sessionStorage.setItem('sessionId', sessionId);
 
     let tabs = [];
     let archivedTabs = [];

--- a/Aurora/public/pipeline_queue.html
+++ b/Aurora/public/pipeline_queue.html
@@ -102,9 +102,8 @@
     </thead>
     <tbody></tbody>
   </table>
+  <script src="session.js"></script>
   <script>
-    const sessionId = sessionStorage.getItem('sessionId') || crypto.randomUUID();
-    sessionStorage.setItem('sessionId', sessionId);
     async function loadQueue(){
       try{
         const res = await fetch('/api/pipelineQueue');

--- a/Aurora/public/session.js
+++ b/Aurora/public/session.js
@@ -1,0 +1,16 @@
+function getCookie(name){
+  const match = document.cookie.split('; ').find(row => row.startsWith(name + '='));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}
+function setCookie(name, value, days=365){
+  const expires = new Date(Date.now() + days*864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+function getSessionId(){
+  let id = getCookie('sessionId') || sessionStorage.getItem('sessionId');
+  if(!id) id = crypto.randomUUID();
+  sessionStorage.setItem('sessionId', id);
+  setCookie('sessionId', id);
+  return id;
+}
+const sessionId = getSessionId();


### PR DESCRIPTION
## Summary
- use a helper script to persist sessionId in a cookie
- update index and feature pages to include the new script
- adjust main.js to use getSessionId()

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*