### PR TITLE
Add image generation quota countdown

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -221,6 +221,7 @@
       <div id="chatMessages"></div>
 
       <div id="waitingCounter"></div>
+      <div id="imageLimitCounter" style="color:#faa;"></div>
       <div class="chat-input-container">
         <!-- Hidden file input for image uploading -->
         <input type="file" id="imageUploadInput" accept="image/*" style="display:none" multiple />

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -198,6 +198,12 @@ body {
   height: 1.2em;
   margin-bottom: 0.5rem;
 }
+#imageLimitCounter {
+  font-size: 0.9rem;
+  color: #faa;
+  height: 1.2em;
+  margin-bottom: 0.5rem;
+}
 
 /* Chat message bubble grouping */
 .chat-sequence {


### PR DESCRIPTION
## Summary
- show a new `#imageLimitCounter` element in chat UI
- style counter in CSS
- track generated image timestamps and limit to 10 images per minute
- disable generate button and display countdown when quota reached
- update button state on page load and after image generation

## Testing
- `npm run lint`