### PR TITLE
Add IP-based image generation limit

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -127,18 +127,14 @@ function showToast(msg, duration=1500){
   setTimeout(() => el.classList.remove("show"), duration);
 }
 
-async function updateImageLimitInfo(files){
+async function updateImageLimitInfo(){
   try {
-    let data = files;
-    if(!data){
-      const resp = await fetch(`/api/upload/list?sessionId=${encodeURIComponent(sessionId)}`);
-      data = await resp.json();
-    }
-    const count = data.filter(f => f.source === 'Generated').length;
+    const resp = await fetch(`/api/image/counts?sessionId=${encodeURIComponent(sessionId)}`);
+    const data = await resp.json();
     const el = document.getElementById('imageLimitInfo');
-    if(el) {
-      el.textContent = `Images: ${count}/10`;
-      if(count >= 10) {
+    if(el){
+      el.textContent = `Images: ${data.sessionCount}/10 (IP ${data.ipCount}/10)`;
+      if(data.sessionCount >= 10 || data.ipCount >= 10){
         el.classList.add('limit-reached');
       } else {
         el.classList.remove('limit-reached');
@@ -2353,7 +2349,7 @@ async function loadFileList() {
     fileListData = await fetch(`/api/upload/list?sessionId=${encodeURIComponent(sessionId)}`).then(r => r.json());
     sortFileData();
     renderFileList();
-    updateImageLimitInfo(fileListData);
+    updateImageLimitInfo();
   } catch(e) {
     console.error("Error fetching file list:", e);
   }

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -543,7 +543,7 @@ body {
    This ensures normal color is used until the limit is hit.
 
    Example HTML after update:
-     <span id="imageLimitInfo" class="session-limit limit-reached">Images: 10/10</span>
+     <span id="imageLimitInfo" class="session-limit limit-reached">Images: 10/10 (IP 10/10)</span>
 
    The dark red color uses the named color `darkred` for clarity.
    It roughly corresponds to #8B0000.


### PR DESCRIPTION
## Summary
- track image generation per IP address
- expose counts via new `/api/image/counts` endpoint
- block `/api/image/generate` when session or IP hits 10
- show session/IP counts in UI

## Testing
- `npm run lint`