### PR TITLE
Add countdown for image limit reduction

### DIFF
--- a/Aurora/public/index.html
+++ b/Aurora/public/index.html
@@ -21,6 +21,7 @@
     <div id="versionInfo" class="version-info" style="margin-bottom: 5px;">Alfe AI beta-2.30 <a href="about.html" target="_blank" style="color: cyan">about</a></div>
     <span id="sessionIdText" class="session-id"></span>
     <span id="imageLimitInfo" class="session-limit"></span>
+    <span id="imageLimitCountdown" class="session-limit"></span>
     <div id="navSpinner" style="text-align:center; margin-top:1rem;"><span class="loading-spinner"></span></div>
     <ul id="navSkeletonList" style="list-style:none;padding:0 1rem;display:none;">
       <li class="nav-placeholder"></li>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -127,17 +127,53 @@ function showToast(msg, duration=1500){
   setTimeout(() => el.classList.remove("show"), duration);
 }
 
+let limitCountdownTimer = null;
+
+function startLimitCountdown(targetTime){
+  const el = document.getElementById('imageLimitCountdown');
+  if(!el) return;
+  function update(){
+    const diff = targetTime - Date.now();
+    if(diff <= 0){
+      clearInterval(limitCountdownTimer);
+      limitCountdownTimer = null;
+      el.textContent = '';
+      updateImageLimitInfo();
+    } else {
+      const m = String(Math.floor(diff/60000)).padStart(2,'0');
+      const s = String(Math.floor((diff%60000)/1000)).padStart(2,'0');
+      el.textContent = `Next slot in ${m}:${s}`;
+    }
+  }
+  if(limitCountdownTimer) clearInterval(limitCountdownTimer);
+  update();
+  limitCountdownTimer = setInterval(update, 1000);
+}
+
+function stopLimitCountdown(){
+  const el = document.getElementById('imageLimitCountdown');
+  if(el) el.textContent = '';
+  if(limitCountdownTimer){
+    clearInterval(limitCountdownTimer);
+    limitCountdownTimer = null;
+  }
+}
+
 async function updateImageLimitInfo(){
   try {
     const resp = await fetch(`/api/image/counts?sessionId=${encodeURIComponent(sessionId)}`);
     const data = await resp.json();
     const el = document.getElementById('imageLimitInfo');
     if(el){
-      el.textContent = `Images: ${data.sessionCount}/10 (IP ${data.ipCount}/10)`;
-      if(data.sessionCount >= 10 || data.ipCount >= 10){
+      el.textContent = `Images: ${data.sessionCount}/${data.sessionLimit} (IP ${data.ipCount}/${data.ipLimit})`;
+      if(data.sessionCount >= data.sessionLimit || data.ipCount >= data.ipLimit){
         el.classList.add('limit-reached');
+        if(data.nextReduction){
+          startLimitCountdown(new Date(data.nextReduction).getTime());
+        }
       } else {
         el.classList.remove('limit-reached');
+        stopLimitCountdown();
       }
     }
   } catch(e){

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -534,6 +534,15 @@ body {
   z-index: 1000;
 }
 
+#imageLimitCountdown.session-limit {
+  position: absolute;
+  top: 44px;
+  left: 60px;
+  font-size: 0.7rem;
+  color: #aaa;
+  z-index: 1000;
+}
+
 /* When the image generation limit is reached (10/10),
    highlight the info text in dark red for visibility
    by applying a new "limit-reached" class via JavaScript.

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1497,7 +1497,8 @@ app.get("/api/image/counts", (req, res) => {
     const ipCount = ipAddress ? db.countImagesForIp(ipAddress) : 0;
     const sessionLimit = sessionId ? db.imageLimitForSession(sessionId, 10) : 10;
     const ipLimit = 10;
-    res.json({ sessionCount, sessionLimit, ipCount, ipLimit });
+    const nextReduction = sessionId ? db.nextImageLimitReductionTime(sessionId) : null;
+    res.json({ sessionCount, sessionLimit, ipCount, ipLimit, nextReduction });
   } catch (err) {
     console.error("[Server Debug] /api/image/counts error:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -877,6 +877,14 @@ export default class TaskDB {
     return Math.max(0, baseLimit - hours);
   }
 
+  nextImageLimitReductionTime(sessionId) {
+    const start = this.getImageSessionStart(sessionId);
+    if (!start) return null;
+    const hours = this.hoursSinceImageSessionStart(sessionId);
+    const nextMs = new Date(start).getTime() + (hours + 1) * 3600 * 1000;
+    return new Date(nextMs).toISOString();
+  }
+
   countImagesForSession(sessionId) {
     if (!sessionId) return 0;
     const row = this.db


### PR DESCRIPTION
## Summary
- display a timer until the image generation limit decreases
- provide next reduction time from the server
- show countdown in UI when 10 images have been generated

## Testing
- `npm run lint`