### PR TITLE
Fix sessionId double declaration

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1,7 +1,4 @@
-// Generate or retrieve a unique session ID stored in cookie/sessionStorage
-const sessionId = typeof getSessionId === 'function'
-  ? getSessionId()
-  : (sessionStorage.getItem('sessionId') || crypto.randomUUID());
+// sessionId is provided globally by session.js
 document.addEventListener('DOMContentLoaded', () => {
   const sessEl = document.getElementById('sessionIdText');
   if (sessEl) sessEl.textContent = sessionId;


### PR DESCRIPTION
## Summary
- use `session.js` sessionId instead of redeclaring the variable in `main.js`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run lint` in Sterling *(fails: Missing script)*
- `npm test` in Sterling *(fails: Missing script)*