### PR TITLE
Fix new tab font color

### DIFF
--- a/Aurora/public/nexum.css
+++ b/Aurora/public/nexum.css
@@ -436,6 +436,15 @@ button:hover {
   color: #fff;
 }
 
+/* Ensure text in the New Tab modal is always white */
+#newTabModal .modal-content,
+#newTabModal label,
+#newTabModal input,
+#newTabModal textarea,
+#newTabModal button {
+  color: #fff;
+}
+
 /* Table styles used on nexum_tabs.html */
 table {
   width: 100%;

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -860,4 +860,13 @@ button:disabled {
   color: #fff;
 }
 
+/* Ensure text in the New Tab modal is always white */
+#newTabModal .modal-content,
+#newTabModal label,
+#newTabModal input,
+#newTabModal textarea,
+#newTabModal button {
+  color: #fff;
+}
+
 


### PR DESCRIPTION
## Summary
- keep new-tab text white in the Aurora UI
- keep new-tab text white in the Nexum UI

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683f6c421a0c8323ab5862f5213b8abf