### PR TITLE
Improve deletion button padding

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -239,6 +239,7 @@ body {
   position: absolute;
   top: 4px;
   right: 4px;
+  padding: 4px;
 }
 
 .bubble-delete-btn {


### PR DESCRIPTION
## Summary
- enlarge the chat pair delete button area for easier access

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683f6caf2ae88323a65398b57b7eef20