### PR TITLE
Change New Tab fields to dark theme

### DIFF
--- a/Aurora/public/nexum.css
+++ b/Aurora/public/nexum.css
@@ -444,6 +444,11 @@ button:hover {
 #newTabModal button {
   color: #fff;
 }
+#newTabModal input,
+#newTabModal textarea {
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+}
 
 /* Table styles used on nexum_tabs.html */
 table {

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -868,5 +868,10 @@ button:disabled {
 #newTabModal button {
   color: #fff;
 }
+#newTabModal input,
+#newTabModal textarea {
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+}
 
 


### PR DESCRIPTION
## Summary
- adjust New Tab modal styles so its inputs and textarea use `var(--bg-main)` background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f6d52550883239a8c9fe77ed801f2