### PR TITLE
Fix spacing of chat buttons

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -258,7 +258,7 @@ body {
 .bubble-copy-btn {
   position: absolute;
   top: 4px;
-  right: 24px;
+  right: 36px; /* increased for better spacing from delete button */
   background: transparent;
   border: none;
   color: #4da3ff;


### PR DESCRIPTION
## Summary
- adjust spacing between copy and delete buttons by moving `.bubble-copy-btn`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683f6e2d23608323a45df00a2dafa00f