### PR TITLE
Fix pair delete button spacing

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -237,7 +237,7 @@ body {
 
 .pair-delete-btn {
   position: absolute;
-  top: 4px;
+  bottom: 4px; /* place at bottom to avoid overlap with bubble delete */
   right: 4px;
   padding: 4px;
 }


### PR DESCRIPTION
## Summary
- reposition pair delete button to bottom-right so it's not cramped next to the user delete button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f6f6263a08323ae02e43b6bbb5019