### PR TITLE
Make favicon circular

### DIFF
--- a/Aurora/public/favicon.svg
+++ b/Aurora/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" ry="12" fill="#2d2d2d"/>
+  <rect width="64" height="64" rx="32" ry="32" fill="#2d2d2d"/>
   <text x="32" y="44" font-family="Arial, Helvetica, sans-serif" font-size="40" fill="#fff" text-anchor="middle" dominant-baseline="central">A</text>
 </svg>


### PR DESCRIPTION
## Summary
- adjust `favicon.svg` so that the browser tab icon has a fully rounded border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683f9ceab784832384ed04d597adba2c