### PR TITLE
Fix sessionId generation fallback

### DIFF
--- a/Aurora/public/session.js
+++ b/Aurora/public/session.js
@@ -6,9 +6,20 @@ function setCookie(name, value, days=365){
   const expires = new Date(Date.now() + days*864e5).toUTCString();
   document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
 }
+function generateUUID(){
+  if(window.crypto && typeof window.crypto.randomUUID === 'function'){
+    return window.crypto.randomUUID();
+  }
+  const template = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+  return template.replace(/[xy]/g, c => {
+    const r = Math.random()*16|0;
+    const v = c === 'x' ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+}
 function getSessionId(){
   let id = getCookie('sessionId') || sessionStorage.getItem('sessionId');
-  if(!id) id = crypto.randomUUID();
+  if(!id) id = generateUUID();
   sessionStorage.setItem('sessionId', id);
   setCookie('sessionId', id);
   return id;


### PR DESCRIPTION
## Summary
- add UUID generator fallback in session.js if `crypto.randomUUID` isn't available

## Testing
- `npm run lint` in `Aurora`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683fa89f884c8323b596f8014c77e83d