### PR TITLE
Fix: hide chat image button

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2215,10 +2215,11 @@ function toggleImageUploadButton(visible){
   btn.style.display = visible ? "" : "none";
 }
 
-function toggleImagePaintTrayButton(visible){
+function toggleImagePaintTrayButton(_visible){
   const btn = document.getElementById("chatGenImageBtn");
   if(!btn) return;
-  btn.style.display = visible ? "" : "none";
+  // Always hide the button. It remains in the DOM but never visible.
+  btn.style.display = "none";
 }
 
 function toggleActivityIframeMenu(visible){


### PR DESCRIPTION
## Summary
- update the JS toggle helper so `chatGenImageBtn` remains hidden

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683fb52e625c83239e2d7a3ed7ebe58c