### PR TITLE
Add batched settings API

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -615,6 +615,29 @@ app.post("/api/tasks/new", async (req, res) => {
   }
 });
 
+app.get("/api/settings", (req, res) => {
+  console.debug("[Server Debug] GET /api/settings =>", req.query.keys);
+  try {
+    const keysParam = req.query.keys;
+    let settings;
+    if (keysParam) {
+      const keys = Array.isArray(keysParam)
+        ? keysParam
+        : String(keysParam)
+            .split(",")
+            .map((k) => k.trim())
+            .filter((k) => k);
+      settings = keys.map((k) => ({ key: k, value: db.getSetting(k) }));
+    } else {
+      settings = db.allSettings();
+    }
+    res.json({ settings });
+  } catch (err) {
+    console.error("[TaskQueue] GET /api/settings failed", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.get("/api/settings/:key", (req, res) => {
   console.debug("[Server Debug] GET /api/settings/:key =>", req.params.key);
   try {


### PR DESCRIPTION
## Summary
- add an API endpoint to fetch many settings in one call
- support batched requests in the UI
- batch load settings for the feature flags modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_683fb6ce42948323bcb977db31ac68eb