### PR TITLE
Hide Sterling project controls

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -164,9 +164,9 @@
       <div id="tabsContainer" style="flex-wrap: wrap; display: flex; gap: 0.5rem;"></div>
       <button id="newTabBtn">➕ Tab</button>
       <button id="scrollDownBtn">Scroll to Bottom</button>
-      <div id="projectInfo" style="font-size:0.9rem; color:#aaa; margin-bottom:4px;"></div>
-      <button id="setProjectBtn">Set Project</button>
-      <button id="createSterlingChatBtn">Create Sterling Chat</button>
+      <div id="projectInfo" style="display:none;font-size:0.9rem; color:#aaa; margin-bottom:4px;"></div>
+      <button id="setProjectBtn" style="display:none;">Set Project</button>
+      <button id="createSterlingChatBtn" style="display:none;">Create Sterling Chat</button>
       <button id="changeSterlingBranchBtn" style="margin-left:6px;">Change Sterling Branch</button>
       <span id="sterlingUrlLabel" style="margin-left:1rem; color:#0f0;"></span>
     </div>


### PR DESCRIPTION
## Summary
- hide `#projectInfo` and related project buttons

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_683fccfe36a08323963bee9702268a07