### PR TITLE
Fix collapsed sidebar logo position

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -169,7 +169,7 @@
       <button id="createSterlingChatBtn" style="display:none;">Create Sterling Chat</button>
       <button id="changeSterlingBranchBtn" style="margin-left:6px;">Change Sterling Branch</button>
       <span id="sterlingUrlLabel" style="margin-left:1rem; color:#0f0;"></span>
-      <img id="collapsedSidebarLogo" src="alfe_favicon_clean_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; margin-left:auto; cursor:pointer; display:none;"/>
+      <img id="collapsedSidebarLogo" src="alfe_favicon_clean_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; position:absolute; top:8px; left:8px; cursor:pointer; display:none; z-index:1000;"/>
     </div>
 
     <!-- New Empty Task List Panel Above Chat UI -->


### PR DESCRIPTION
## Summary
- move the collapsed sidebar logo to the top-left corner

## Testing
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm test` in `VMRunner` *(fails: no test specified)*
- `npm test` in `stirfry/stirfry` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683fce2b8d908323913798ef9404866f