### PR TITLE
Fix chat bar overlap when sidebar collapsed

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -262,6 +262,17 @@ async function toggleSidebar(){
   const expandBtn = document.getElementById("expandSidebarBtn");
   expandBtn.style.display = sidebarVisible ? "none" : "block";
 
+  // Shift top chat tabs bar when sidebar is collapsed so it doesn't
+  // overlap the logo icon in the top left.
+  const appEl = document.querySelector(".app");
+  if(appEl){
+    if(sidebarVisible){
+      appEl.classList.remove("sidebar-collapsed");
+    } else {
+      appEl.classList.add("sidebar-collapsed");
+    }
+  }
+
   await setSetting("sidebar_visible", sidebarVisible);
 }
 const toggleSidebarBtn = $("#toggleSidebarBtn");
@@ -380,6 +391,14 @@ async function loadSettings(){
       toggleSidebarBtn.textContent = sidebarVisible ? "Hide sidebar" : "Show sidebar";
     }
     document.getElementById("expandSidebarBtn").style.display = sidebarVisible ? "none" : "block";
+    const appEl = document.querySelector(".app");
+    if(appEl){
+      if(sidebarVisible){
+        appEl.classList.remove("sidebar-collapsed");
+      } else {
+        appEl.classList.add("sidebar-collapsed");
+      }
+    }
   }
   {
     const r = await fetch("/api/settings/enter_submits_message");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -446,6 +446,11 @@ body {
   margin-bottom: 0;
 }
 
+/* When sidebar is collapsed, shift the chat tabs bar to clear the logo */
+.app.sidebar-collapsed #chatTabs {
+  margin-left: 60px;
+}
+
 /* Icon displayed before chat tab names */
 #tabsContainer .tab-icon,
 #verticalTabsContainer .tab-icon {


### PR DESCRIPTION
## Summary
- keep track of sidebar state with new `sidebar-collapsed` class
- move chat tabs right when sidebar is hidden

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683fcf8c018483238f4978e22a6881d1