### PR TITLE
Implement page reload when new tab added

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1068,7 +1068,8 @@ async function addNewTab(){
     renderTabs();
     renderSidebarTabs();
     renderArchivedSidebarTabs();
-    // TODO: IMPLEMENT RELOADING THE ENTIRE PAGE HERE.
+    // Reload the entire page so the new tab state is fully reflected
+    window.location.reload();
   }
 }
 async function renameTab(tabId){


### PR DESCRIPTION
## Summary
- reload the page after adding a new chat tab to ensure new tab state is reflected

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683fd86ff76c83239cab701758d3d4a9