### PR TITLE
Fix nav order for Chats button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -35,8 +35,8 @@
     <!-- Tree-style menu with sections -->
     <nav class="tree-menu" style="display:none;">
       <ul>
-        <li><button id="navUploaderBtn" class="tree-button">Images</button></li>
         <li><button id="navChatTabsBtn" class="tree-button" hidden>Chats</button></li>
+        <li><button id="navUploaderBtn" class="tree-button">Images</button></li>
         <li><button id="navArchiveTabsBtn" class="tree-button">Archived</button></li>
         <li><button id="navTasksBtn" class="tree-button active">Tasks</button></li>
         <li><button id="navFileTreeBtn" class="tree-button">File Tree</button></li>


### PR DESCRIPTION
## Summary
- update nav menu ordering to put Chats above Images

## Testing
- `npm test` *(fails: Missing script)*
- `npx ejs-lint executable/views/*.ejs` *(fails: unable to access npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_683fe5c95598832386d96c62d2bfd29f