### PR TITLE
Add optional HTTPS support

### DIFF
--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -23,6 +23,8 @@ npm start
 | `UPSCALE_SCRIPT_PATH` | (Optional) Path to the image upscale script. Defaults to the included loop.sh |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |
+| `HTTPS_KEY_PATH` | (Optional) Path to SSL private key for HTTPS |
+| `HTTPS_CERT_PATH` | (Optional) Path to SSL certificate for HTTPS |
 
 ### Obtaining API Keys
 1. **GitHub Token**:  

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
+import https from "https";
 import GitHubClient from "./githubClient.js";
 import TaskQueue from "./taskQueue.js";
 import TaskDB from "./taskDb.js";
@@ -2447,6 +2448,19 @@ app.post("/api/markdown", (req, res) => {
 
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`[TaskQueue] Web server is running on port ${PORT} (verbose='true')`);
-});
+const keyPath = process.env.HTTPS_KEY_PATH;
+const certPath = process.env.HTTPS_CERT_PATH;
+
+if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+  const options = {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath)
+  };
+  https.createServer(options, app).listen(PORT, () => {
+    console.log(`[TaskQueue] HTTPS server running on port ${PORT}`);
+  });
+} else {
+  app.listen(PORT, () => {
+    console.log(`[TaskQueue] Web server is running on port ${PORT} (verbose='true')`);
+  });
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Alfe AI beta-0.4x+ (Software Development): https://github.com/alfe-ai/Sterling
 wget https://raw.githubusercontent.com/alfe-ai/alfe-ai-Aurelix/refs/heads/Aurora/Aurelix/dev/main-rel2/deploy_aurelix.sh && chmod +x deploy_aurelix.sh && ./deploy_aurelix.sh
 ```
 
-#### 2.0 Beta (Aurora/Aurelix)  
+#### 2.0 Beta (Aurora/Aurelix)
 
 ![image](https://github.com/user-attachments/assets/ec47be87-5577-45b2-a3af-17475860df46)
+
+### Environment variables
+
+Set `HTTPS_KEY_PATH` and `HTTPS_CERT_PATH` to the SSL key and certificate files
+to enable HTTPS across the included servers. If the files are missing the
+services fall back to HTTP.

--- a/Sterling/README.md
+++ b/Sterling/README.md
@@ -76,6 +76,15 @@ found 0 vulnerabilities
 
 <!-- 8. In new chats, you can copy Agent Instructions from here: https://github.com/alfe-ai/alfe-agent_instructions (This will soon be integrated with the app)--><!--, I implemented this in an older branch, multiple agent support.)-->
 
+### Environment variables
+
+To run the web server over HTTPS, provide paths to your SSL certificate files:
+
+- `HTTPS_KEY_PATH` – path to your private key
+- `HTTPS_CERT_PATH` – path to your certificate
+
+If both files exist the server starts in HTTPS mode, otherwise it falls back to HTTP.
+
 ### Related Repositories:  
 Alfe AI / Agent Instructions: https://github.com/alfe-ai/alfe-agent_instructions
 

--- a/Sterling/executable/server_webserver.js
+++ b/Sterling/executable/server_webserver.js
@@ -8,6 +8,7 @@ const multer = require("multer");
 const bodyParser = require("body-parser");
 const cron = require("node-cron");
 const http = require("http");
+const https = require("https");
 const { OpenAI } = require("openai");
 const app = express();
 
@@ -482,6 +483,20 @@ if (process.env.DEBUG) {
 } else {
     port = process.env.SERVER_PORT || 3000;
 }
-http.createServer(app).listen(port, () => {
-    console.log(`[DEBUG] Server running => http://localhost:${port}`);
-});
+
+const keyPath = process.env.HTTPS_KEY_PATH;
+const certPath = process.env.HTTPS_CERT_PATH;
+
+if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+    const options = {
+        key: fs.readFileSync(keyPath),
+        cert: fs.readFileSync(certPath),
+    };
+    https.createServer(options, app).listen(port, () => {
+        console.log(`[DEBUG] HTTPS server running => https://localhost:${port}`);
+    });
+} else {
+    http.createServer(app).listen(port, () => {
+        console.log(`[DEBUG] Server running => http://localhost:${port}`);
+    });
+}

--- a/VMRunner/README.md
+++ b/VMRunner/README.md
@@ -27,6 +27,11 @@ npm start
 ```
 Then open `http://localhost:3000` in your browser.
 
+### Environment variables
+
+`HTTPS_KEY_PATH` and `HTTPS_CERT_PATH` can be set to enable HTTPS if you provide
+paths to your SSL key and certificate. Without them the server uses HTTP.
+
 ## Note
 
 The repository does not include the WebVM source or disk images. Those need to be fetched separately when you have internet access.

--- a/VMRunner/server.js
+++ b/VMRunner/server.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -9,4 +12,19 @@ app.use('/', express.static(path.join(__dirname, 'webvm-source', 'build')));
 // Serve disk images
 app.use('/disk-images', express.static(path.join(__dirname, 'disk-images')));
 
-app.listen(PORT, () => console.log(`VMRunner running at http://localhost:${PORT}`));
+const keyPath = process.env.HTTPS_KEY_PATH;
+const certPath = process.env.HTTPS_CERT_PATH;
+
+if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+  const options = {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath)
+  };
+  https.createServer(options, app).listen(PORT, () => {
+    console.log(`VMRunner running at https://localhost:${PORT}`);
+  });
+} else {
+  http.createServer(app).listen(PORT, () => {
+    console.log(`VMRunner running at http://localhost:${PORT}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add HTTPS server logic for Aurora when cert files are provided
- allow Sterling server to run on HTTPS
- support HTTPS in VMRunner
- document new HTTPS-related environment variables in all READMEs

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm test` in `VMRunner` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683fe85c49948323be324e96256a9040