### PR TITLE
Allow custom port for Aurora

### DIFF
--- a/Aurora/.env.example
+++ b/Aurora/.env.example
@@ -12,3 +12,6 @@ GITHUB_REPO=yourRepo
 
 # Base URL of your self-hosted Stable Diffusion API (optional)
 # STABLE_DIFFUSION_URL=http://localhost:7860
+
+# Port for the Aurora web server (optional)
+# AURORA_PORT=3000

--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -25,6 +25,7 @@ npm start
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |
 | `HTTPS_KEY_PATH` | (Optional) Path to SSL private key for HTTPS |
 | `HTTPS_CERT_PATH` | (Optional) Path to SSL certificate for HTTPS |
+| `AURORA_PORT` | (Optional) Port for the web server (default: 3000) |
 
 Run `../setup_certbot.sh <domain> <email>` to quickly generate these files with
 Let's Encrypt.

--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -134,7 +134,7 @@
     <!-- New Activity IFrame panel -->
     <div id="sidebarViewActivityIframe" style="display:none;">
       <h2>Activity IFrame</h2>
-      <iframe src="http://localhost:3000/activity" style="width:100%; height:800px; border:none;"></iframe>
+      <iframe src="/activity" style="width:100%; height:800px; border:none;"></iframe>
     </div>
   </aside>
 

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2447,7 +2447,10 @@ app.post("/api/markdown", (req, res) => {
 });
 
 
-const PORT = process.env.PORT || 3000;
+const PORT =
+  process.env.AURORA_PORT ||
+  process.env.PORT ||
+  3000;
 const keyPath = process.env.HTTPS_KEY_PATH;
 const certPath = process.env.HTTPS_CERT_PATH;
 


### PR DESCRIPTION
## Summary
- make Aurora's server port configurable via `AURORA_PORT`
- document `AURORA_PORT` in README
- provide sample variable in `.env.example`
- use relative URL for Activity iframe

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840ad42f0e88323ad60da14b1eeb62b