### PR TITLE
Add port 443 forwarding helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ services fall back to HTTP.
 You can quickly obtain free certificates from Let's Encrypt by running the
 `setup_certbot.sh` script. It installs Certbot and generates the key and
 certificate files for the domain you specify.
+
+### Listening on port 443 without root
+
+The Aurora server reads its port from the `AURORA_PORT` environment variable
+(default: `3000`). Binding directly to port `443` typically requires root
+privileges. If you prefer to run the server as a regular user, you can forward
+incoming connections from port `443` to your configured `AURORA_PORT`.
+
+Run the helper script with `sudo` to set up the forwarding rule:
+
+```bash
+sudo ./forward_port_443.sh 3000
+```
+
+Replace `3000` with your chosen `AURORA_PORT`. After adding the rule, start the
+server normally and clients can connect using `https://your-domain/` on port
+`443` while the Node.js process continues to run on the higher port.

--- a/forward_port_443.sh
+++ b/forward_port_443.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# forward_port_443.sh - Forward port 443 to a higher user port using iptables
+# Usage: sudo ./forward_port_443.sh <target_port>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: sudo $0 <target_port>" >&2
+  exit 1
+fi
+
+TARGET_PORT="$1"
+
+# Forward incoming HTTPS traffic to the specified port
+iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port "$TARGET_PORT"
+
+echo "Forwarding HTTPS (443) -> $TARGET_PORT"


### PR DESCRIPTION
## Summary
- add a helper script to forward port 443 to a user-level port with iptables
- document how to run the server on port 443 without root

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840aedf31848323a7a222603cf46547