### PR TITLE
Fix Aurora logo visibility when tabs hidden

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -153,6 +153,7 @@
   <div id="expandSidebarBtn" style="position: absolute; top: 75px; left: 8px; background: #444; color: #ddd; padding: 4px 8px; cursor: pointer; z-index: 999; display: none;">
     Show Sidebar
   </div>
+  <img id="collapsedSidebarLogo" src="alfe_favicon_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; position:absolute; top:8px; left:8px; cursor:pointer; display:none; z-index:1000;"/>
 
   <main class="chat-panel">
     <div id="viewTabsBar" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;" hidden>
@@ -169,7 +170,6 @@
       <button id="createSterlingChatBtn" style="display:none;">Create Sterling Chat</button>
       <button id="changeSterlingBranchBtn" style="margin-left:6px;">Change Sterling Branch</button>
       <span id="sterlingUrlLabel" style="margin-left:1rem; color:#0f0;"></span>
-      <img id="collapsedSidebarLogo" src="alfe_favicon_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; position:absolute; top:8px; left:8px; cursor:pointer; display:none; z-index:1000;"/>
     </div>
 
     <!-- New Empty Task List Panel Above Chat UI -->


### PR DESCRIPTION
## Summary
- keep the collapsed-sidebar logo visible even if the chat tabs bar is hidden

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840b74cc36c8323b09eab6b1614018c