### PR TITLE
Add rename button for Aurora chat tabs

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1198,6 +1198,12 @@ function renderTabs(){
     nameSpan.addEventListener("click", ()=>selectTab(tab.id));
     tabBtn.appendChild(nameSpan);
 
+    const renameBtn = document.createElement("button");
+    renameBtn.textContent = "Rename";
+    renameBtn.style.marginLeft = "4px";
+    renameBtn.addEventListener("click", e=>{ e.stopPropagation(); renameTab(tab.id); });
+    tabBtn.appendChild(renameBtn);
+
     const archBtn = document.createElement("button");
     archBtn.innerHTML = tab.archived ? "Unarchive" : "&#128452;";
     archBtn.title = tab.archived ? "Unarchive" : "Archive";
@@ -1259,6 +1265,13 @@ function renderSidebarTabs(){
     info.appendChild(b);
     info.appendChild(dateSpan);
 
+    const renameBtn = document.createElement("button");
+    renameBtn.textContent = "Rename";
+    renameBtn.addEventListener("click", e => {
+      e.stopPropagation();
+      renameTab(tab.id);
+    });
+
     const archBtn = document.createElement("button");
     archBtn.innerHTML = tab.archived ? "Unarchive" : "&#128452;";
     archBtn.title = tab.archived ? "Unarchive" : "Archive";
@@ -1268,6 +1281,7 @@ function renderSidebarTabs(){
     });
 
     wrapper.appendChild(info);
+    wrapper.appendChild(renameBtn);
     wrapper.appendChild(archBtn);
     container.appendChild(wrapper);
   });

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -404,6 +404,11 @@
         gear.className = 'config-btn';
         gear.addEventListener('click', (e) => { e.stopPropagation(); openTabConfig(t.id); });
 
+        const renameBtn = document.createElement('button');
+        renameBtn.textContent = 'Rename';
+        renameBtn.className = 'config-btn';
+        renameBtn.addEventListener('click', e => { e.stopPropagation(); renameTab(t.id); });
+
         const archBtn = document.createElement('button');
         archBtn.innerHTML = t.archived ? 'Unarchive' : '&#128452;';
         archBtn.title = t.archived ? 'Unarchive' : 'Archive';
@@ -415,7 +420,8 @@
 
         item.appendChild(b);
         item.appendChild(gear);
-      item.appendChild(archBtn);
+        item.appendChild(renameBtn);
+        item.appendChild(archBtn);
       container.appendChild(item);
     });
     checkNoTabsDialog();


### PR DESCRIPTION
## Summary
- add a rename button next to the archive tab control in `nexum.html`
- support the same rename control in `main.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840c3e033648323a69d738ce42b546c