### PR TITLE
Prefix API version with beta

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2481,7 +2481,7 @@ app.get("/api/version", (req, res) => {
       })
       .toString()
       .trim();
-    res.json({ version: latestTag });
+    res.json({ version: `beta-${latestTag}` });
   } catch (err) {
     console.error("[Server Debug] GET /api/version =>", err);
     res.status(500).json({ error: "Unable to determine version" });


### PR DESCRIPTION
## Summary
- prefix git tag version with `beta-` in the `/api/version` endpoint

## Testing
- `npm run lint --prefix Aurora`
- `node -e "const cp=require('child_process'); const latest=cp.execSync('git tag --sort=-creatordate | head -n 1').toString().trim(); console.log('beta-'+latest);"`

------
https://chatgpt.com/codex/tasks/task_b_6840c683b8408323b224dc49d16f7615