### PR TITLE
UI update: gear to top right

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -146,9 +146,10 @@
   <div id="topRightButtons" class="top-right-buttons">
 <!--    <span class="subscribe-teaser">Join the beta:</span>-->
 <!--    <a id="subscribeBtn" href="#" class="top-btn">Subscribe</a>-->
-    <a id="githubBtn" href="https://github.com/alfe-ai" target="_blank" class="top-btn">GitHub</a>
+      <a id="githubBtn" href="https://github.com/alfe-ai" target="_blank" class="top-btn">GitHub</a>
+      <button id="chatSettingsBtn" class="top-btn" title="Chat Settings">⚙️</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
-  </div>
+    </div>
 
   <div id="expandSidebarBtn" style="position: absolute; top: 75px; left: 8px; background: #444; color: #ddd; padding: 4px 8px; cursor: pointer; z-index: 999; display: none;">
     Show Sidebar
@@ -197,11 +198,10 @@
       <div id="subroutineCards" style="display:flex; gap:8px; margin-top:8px;"></div>
     </div>
 
-    <div id="chatPanel" style="position: relative;">
-      <div style="display: flex; align-items: center; gap: 0.5rem;">
-        <div id="modelHud" style="font-size:0.9rem; color:#aaa; margin-bottom:4px;"></div>
-        <button id="chatSettingsBtn" title="Chat Settings">⚙️</button>
-      </div>
+      <div id="chatPanel" style="position: relative;">
+        <div style="display: flex; align-items: center; gap: 0.5rem;">
+          <div id="modelHud" style="font-size:0.9rem; color:#aaa; margin-bottom:4px;"></div>
+        </div>
 
       <!-- New 'model tabs' section -->
       <div id="modelTabs" style="display:flex; gap:0.5rem; align-items:center; margin-bottom:4px;">


### PR DESCRIPTION
## Summary
- reposition chat settings gear next to GitHub button in the header

## Testing
- `npm run lint` in `Aurora`
- `npm run start` in `Sterling` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6840cbef777883239025915e4da757e8