### PR TITLE
Increase image gen limit

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -579,7 +579,7 @@ body {
   display: none !important;
 }
 
-/* When the image generation limit is reached (10/10),
+/* When the image generation limit is reached (50/50),
    highlight the info text in dark red for visibility
    by applying a new "limit-reached" class via JavaScript.
    This class is added dynamically when the count hits the limit.
@@ -588,7 +588,7 @@ body {
    This ensures normal color is used until the limit is hit.
 
    Example HTML after update:
-     <span id="imageLimitInfo" class="session-limit limit-reached">Images: 10/10 (IP 10/10)</span>
+     <span id="imageLimitInfo" class="session-limit limit-reached">Images: 50/50 (IP 50/50)</span>
 
    The dark red color uses the named color `darkred` for clarity.
    It roughly corresponds to #8B0000.

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1647,8 +1647,8 @@ app.get("/api/image/counts", (req, res) => {
     const ipAddress = (req.headers["x-forwarded-for"] || req.ip || "").split(",")[0].trim();
     const sessionCount = sessionId ? db.countImagesForSession(sessionId) : 0;
     const ipCount = ipAddress ? db.countImagesForIp(ipAddress) : 0;
-    const sessionLimit = sessionId ? db.imageLimitForSession(sessionId, 10) : 10;
-    const ipLimit = 10;
+    const sessionLimit = sessionId ? db.imageLimitForSession(sessionId, 50) : 50;
+    const ipLimit = 50;
     const nextReduction = sessionId ? db.nextImageLimitReductionTime(sessionId) : null;
     res.json({ sessionCount, sessionLimit, ipCount, ipLimit, nextReduction });
   } catch (err) {
@@ -2083,7 +2083,7 @@ app.post("/api/image/generate", async (req, res) => {
     if (sessionId) {
       db.ensureImageSession(sessionId);
       const current = db.countImagesForSession(sessionId);
-      const limit = db.imageLimitForSession(sessionId, 10);
+      const limit = db.imageLimitForSession(sessionId, 50);
       if (current >= limit) {
         return res.status(400).json({ error: 'Image generation limit reached for this session' });
       }
@@ -2091,7 +2091,7 @@ app.post("/api/image/generate", async (req, res) => {
 
     if (ipAddress) {
       const ipCount = db.countImagesForIp(ipAddress);
-      if (ipCount >= 10) {
+      if (ipCount >= 50) {
         return res.status(400).json({ error: 'Image generation limit reached for this IP' });
       }
     }

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -881,7 +881,7 @@ export default class TaskDB {
     return Math.floor(diffMs / (3600 * 1000));
   }
 
-  imageLimitForSession(sessionId, baseLimit = 10) {
+  imageLimitForSession(sessionId, baseLimit = 50) {
     const hours = this.hoursSinceImageSessionStart(sessionId);
     return Math.max(0, baseLimit - hours);
   }


### PR DESCRIPTION
## Summary
- bump session & IP image limits from 10 to 50
- adjust database default limit
- update CSS comments

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840cccc14288323bcb9d6f18bd013de