### PR TITLE
Add toggle for session ID display

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -556,6 +556,7 @@
     <label><input type="checkbox" id="chatTabsMenuCheck"/> Show Chats button</label><br/>
     <label><input type="checkbox" id="viewTabsBarFlagCheck"/> Show Chat/Tasks bar</label><br/>
     <label><input type="checkbox" id="showProjectNameTabsCheck"/> Show project name in tabs</label><br/>
+    <label><input type="checkbox" id="showSessionIdCheck"/> Show Session ID</label><br/>
     <label><input type="checkbox" id="imageGeneratorMenuCheck"/> Show Image Generator menu</label>
     <br/>
     <label><input type="checkbox" id="upArrowHistoryCheck" checked/> Enable Arrow Up history recall</label>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -70,6 +70,7 @@ let aiModelsMenuVisible = false;      // show AI Models link
 let tasksMenuVisible = false;         // show Tasks button
 let jobsMenuVisible = false;         // show Jobs button
 let chatTabsMenuVisible = true;     // show Chats button
+let showSessionId = false;          // display session ID hash
 let upArrowHistoryEnabled = true;    // use Arrow Up/Down for input history
 let newTabProjectNameEnabled = true; // show Project name field in New Tab dialog
 let chatSubroutines = [];
@@ -400,6 +401,7 @@ async function loadSettings(){
     "image_generator_menu_visible","file_tree_menu_visible",
     "ai_models_menu_visible","tasks_menu_visible","jobs_menu_visible",
     "chat_tabs_menu_visible","up_arrow_history_enabled",
+    "show_session_id",
     "new_tab_project_enabled"
   ];
   const map = await getSettings(keys);
@@ -566,6 +568,11 @@ async function loadSettings(){
     chatTabsMenuVisible = map.chat_tabs_menu_visible !== false;
   }
   toggleChatTabsMenu(chatTabsMenuVisible);
+
+  if(typeof map.show_session_id !== "undefined"){
+    showSessionId = map.show_session_id !== false;
+  }
+  toggleSessionIdVisibility(showSessionId);
 
   if(typeof map.up_arrow_history_enabled !== "undefined"){
     upArrowHistoryEnabled = map.up_arrow_history_enabled !== false;
@@ -2154,6 +2161,12 @@ function toggleViewTabsBarVisibility(visible) {
   const bar = document.getElementById("viewTabsBar");
   if(!bar) return;
   bar.style.display = visible ? "" : "none";
+}
+
+function toggleSessionIdVisibility(visible) {
+  const el = document.getElementById("sessionIdText");
+  if(!el) return;
+  el.style.display = visible ? "inline" : "none";
 }
 
 function setLoopUi(active){
@@ -3771,7 +3784,8 @@ async function loadFeatureFlags(){
     "nexum_chat_menu_visible","nexum_tabs_menu_visible","image_generator_menu_visible",
     "file_tree_menu_visible","ai_models_menu_visible","tasks_menu_visible",
     "jobs_menu_visible","view_tabs_bar_visible","chat_tabs_menu_visible",
-    "show_project_name_in_tabs","up_arrow_history_enabled","new_tab_project_enabled"
+    "show_project_name_in_tabs","up_arrow_history_enabled","new_tab_project_enabled",
+    "show_session_id"
   ];
   const map = await getSettings(keys);
   if(typeof map.image_upload_enabled !== "undefined") imageUploadEnabled = !!map.image_upload_enabled;
@@ -3789,6 +3803,7 @@ async function loadFeatureFlags(){
   if(typeof map.show_project_name_in_tabs !== "undefined") showProjectNameInTabs = map.show_project_name_in_tabs !== false;
   if(typeof map.up_arrow_history_enabled !== "undefined") upArrowHistoryEnabled = map.up_arrow_history_enabled !== false;
   if(typeof map.new_tab_project_enabled !== "undefined") newTabProjectNameEnabled = map.new_tab_project_enabled !== false;
+  if(typeof map.show_session_id !== "undefined") showSessionId = map.show_session_id !== false;
 }
 
 document.getElementById("featureFlagsBtn").addEventListener("click", async () => {
@@ -3805,6 +3820,7 @@ document.getElementById("featureFlagsBtn").addEventListener("click", async () =>
   document.getElementById("chatTabsMenuCheck").checked = chatTabsMenuVisible;
   document.getElementById("viewTabsBarFlagCheck").checked = viewTabsBarVisible;
   document.getElementById("showProjectNameTabsCheck").checked = showProjectNameInTabs;
+  document.getElementById("showSessionIdCheck").checked = showSessionId;
   document.getElementById("imageGeneratorMenuCheck").checked = imageGeneratorMenuVisible;
   document.getElementById("upArrowHistoryCheck").checked = upArrowHistoryEnabled;
   document.getElementById("newTabProjectFlagCheck").checked = newTabProjectNameEnabled;
@@ -3827,6 +3843,7 @@ document.getElementById("featureFlagsSaveBtn").addEventListener("click", async (
   chatTabsMenuVisible = document.getElementById("chatTabsMenuCheck").checked;
   viewTabsBarVisible = document.getElementById("viewTabsBarFlagCheck").checked;
   showProjectNameInTabs = document.getElementById("showProjectNameTabsCheck").checked;
+  showSessionId = document.getElementById("showSessionIdCheck").checked;
   upArrowHistoryEnabled = document.getElementById("upArrowHistoryCheck").checked;
   newTabProjectNameEnabled = document.getElementById("newTabProjectFlagCheck").checked;
   imageGeneratorMenuVisible = document.getElementById("imageGeneratorMenuCheck").checked;
@@ -3840,6 +3857,7 @@ document.getElementById("featureFlagsSaveBtn").addEventListener("click", async (
   await setSetting("chat_tabs_menu_visible", chatTabsMenuVisible);
   await setSetting("view_tabs_bar_visible", viewTabsBarVisible);
   await setSetting("show_project_name_in_tabs", showProjectNameInTabs);
+  await setSetting("show_session_id", showSessionId);
   await setSetting("up_arrow_history_enabled", upArrowHistoryEnabled);
   await setSetting("new_tab_project_enabled", newTabProjectNameEnabled);
   await setSetting("image_generator_menu_visible", imageGeneratorMenuVisible);
@@ -3851,6 +3869,7 @@ document.getElementById("featureFlagsSaveBtn").addEventListener("click", async (
   toggleTasksMenu(tasksMenuVisible);
   toggleJobsMenu(jobsMenuVisible);
   toggleChatTabsMenu(chatTabsMenuVisible);
+  toggleSessionIdVisibility(showSessionId);
   toggleViewTabsBarVisibility(viewTabsBarVisible);
   toggleImageGeneratorMenu(imageGeneratorMenuVisible);
   renderTabs();

--- a/Aurora/public/nexum.html
+++ b/Aurora/public/nexum.html
@@ -226,7 +226,7 @@
         <p>Nexum is the experimental interface for the Alfe AI project. It combines chat, code generation and task management features to assist developers.</p>
         <p><strong>Our Story</strong></p>
         <p>We started in 2022 with a task management prototype called Aurora. The idea matured into Nexum, and by May 2025 we're focusing on integrating AI tools to streamline developer workflows.</p>
-        <p id="sessionIdDisplay" style="margin-top:0.5rem;">Session ID: <span id="sessionIdText"></span></p>
+        <p id="sessionIdDisplay" style="margin-top:0.5rem; display:none;">Session ID: <span id="sessionIdText"></span></p>
       </div>
     </div>
   </div>
@@ -880,6 +880,14 @@
       // Display the generated session ID in the About overlay
       const sessEl = document.getElementById('sessionIdText');
       if(sessEl) sessEl.textContent = sessionId;
+      fetch('/api/settings/show_session_id')
+        .then(r => r.ok ? r.json() : { value: false })
+        .then(d => {
+          const show = d.value !== false;
+          const displayEl = document.getElementById('sessionIdDisplay');
+          if(displayEl) displayEl.style.display = show ? 'block' : 'none';
+        })
+        .catch(() => {});
 
       document.getElementById('sendBtn').addEventListener('click',send);
       document.getElementById('askBtn').addEventListener('click',send);

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -531,6 +531,7 @@ body {
 
 /* Display session ID next to the sidebar icon */
 #sessionIdText.session-id {
+  display: none;
   position: absolute;
   top: 16px;
   left: 60px;

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -147,6 +147,11 @@ if (!db.getSetting("image_gen_service")) {
   db.setSetting("image_gen_service", "openai");
 }
 
+console.debug("[Server Debug] Checking or setting default 'show_session_id' in DB...");
+if (db.getSetting("show_session_id") === undefined) {
+  db.setSetting("show_session_id", false);
+}
+
 const app = express();
 const jobManager = new JobManager();
 


### PR DESCRIPTION
## Summary
- allow toggling of the session ID hash display via a new `show_session_id` setting
- default the session ID display to hidden
- expose checkbox in Feature Flags modal
- respect the setting on the Nexum page as well

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840cb8f009c832391eae314ab72a5a0