### PR TITLE
Fix mobile sidebar default

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -34,7 +34,7 @@ let modelName = "unknown";
 let tasksVisible = true;
 let markdownPanelVisible = false;
 let subroutinePanelVisible = false;
-let sidebarVisible = true;
+let sidebarVisible = window.innerWidth > 700;
 let chatTabs = [];
 let archivedTabs = [];
 let currentTabId = 1;
@@ -434,6 +434,8 @@ async function loadSettings(){
 
   if(typeof map.sidebar_visible !== "undefined"){
     sidebarVisible = !!map.sidebar_visible;
+  } else if(isMobileViewport()){
+    sidebarVisible = false;
   }
   $(".sidebar").style.display = sidebarVisible ? "" : "none";
   $("#divider").style.display = sidebarVisible ? "" : "none";


### PR DESCRIPTION
## Summary
- collapse sidebar by default on narrow/mobile viewports
- fall back to collapsed sidebar when sidebar setting isn't stored

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840cc8d59388323a340d81ff67c15f0