### PR TITLE
Fix sidebar width clamping

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -481,7 +481,9 @@ async function loadSettings(){
   }
 
   if(typeof map.sidebar_width !== "undefined"){
-    $(".sidebar").style.width = map.sidebar_width + "px";
+    const maxW = window.innerWidth;
+    const width = Math.min(map.sidebar_width, maxW);
+    $(".sidebar").style.width = width + "px";
   }
 
   if(typeof map.model_tabs_bar_visible !== "undefined"){
@@ -2303,9 +2305,11 @@ function runImageLoop(){
     const dx = e.clientX - startX;
     const newWidth = startWidth + dx;
     const minWidth = 150;
+    const maxWidth = window.innerWidth;
     if(newWidth >= minWidth) {
-      $(".sidebar").style.width = newWidth + "px";
-      finalWidth = newWidth;
+      const clamped = Math.min(newWidth, maxWidth);
+      $(".sidebar").style.width = clamped + "px";
+      finalWidth = clamped;
     }
   });
 


### PR DESCRIPTION
## Summary
- clamp sidebar width to the current viewport when settings are loaded
- prevent dragging sidebar wider than the viewport

## Testing
- `npm run lint` (Aurora)
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840d1a8ea0c83238f3dd921f9787da1