### PR TITLE
Fix light theme sidebar color

### DIFF
--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -27,10 +27,11 @@ body {
 .sidebar {
   position: relative;
   width: 300px;
-  background: #2d2d2d;
+  background: var(--bg-main);
+  color: var(--text-color);
   padding: 3.5rem 1rem 1rem 1rem; /* leave room for toggle icon */
   overflow-y: auto;
-  border-right: 1px solid #aaa;
+  border-right: 1px solid var(--border);
   flex: none; /* Keep fixed width */
 }
 


### PR DESCRIPTION
## Summary
- keep sidebar light when light theme is selected

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840d17d4ee88323b37b28f171c7a0fd