### PR TITLE
Add chat loading spinner

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -213,6 +213,9 @@
       </div>
 
       <div id="chatMessages"></div>
+      <div id="chatPlaceholder" style="display:none;text-align:center;margin:1rem 0;">
+        <span class="loading-spinner"></span>
+      </div>
 
       <div id="waitingCounter"></div>
       <div class="chat-input-container">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1578,6 +1578,7 @@ chatInputEl.addEventListener("keydown", (e) => {
 
 chatSendBtnEl.addEventListener("click", async () => {
   const chatMessagesEl = document.getElementById("chatMessages");
+  const placeholderEl = document.getElementById("chatPlaceholder");
   const userMessage = chatInputEl.value.trim();
   if(!userMessage && pendingImages.length===0) return;
   if(userMessage){
@@ -1722,6 +1723,7 @@ chatSendBtnEl.addEventListener("click", async () => {
   botDiv.appendChild(botBody);
 
   seqDiv.appendChild(botDiv);
+  if(placeholderEl) placeholderEl.style.display = "none";
   chatMessagesEl.appendChild(seqDiv);
   chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
   setTimeout(scrollChatToBottom, 0);
@@ -3053,10 +3055,12 @@ let chatHasMore = true;
 
 async function loadChatHistory(tabId = 1, reset=false) {
   const chatMessagesEl = document.getElementById("chatMessages");
+  const placeholderEl = document.getElementById("chatPlaceholder");
   if(reset){
     chatMessagesEl.innerHTML="";
     chatHistoryOffset = 0;
     chatHasMore = true;
+    if(placeholderEl) placeholderEl.style.display = "";
   }
   try {
     const resp = await fetch(`/api/chat/history?tabId=${tabId}&limit=10&offset=${chatHistoryOffset}&sessionId=${encodeURIComponent(sessionId)}`);
@@ -3080,6 +3084,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
             p.image_url, p.image_alt, p.image_title
         );
       }
+      if(pairs.length>0 && placeholderEl) placeholderEl.style.display = "none";
       scrollChatToBottom();
     } else {
       const scrollPos = chatMessagesEl.scrollHeight;
@@ -3227,6 +3232,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
         chatMessagesEl.appendChild(fragment);
       }
       chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight - scrollPos;
+      if(pairs.length>0 && placeholderEl) placeholderEl.style.display = "none";
     }
   } catch (err) {
     console.error("Error loading chat history:", err);
@@ -3472,6 +3478,8 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
   seqDiv.appendChild(pairDelBtn);
 
   const chatMessagesEl = document.getElementById("chatMessages");
+  const placeholderEl = document.getElementById("chatPlaceholder");
+  if(placeholderEl) placeholderEl.style.display = "none";
   chatMessagesEl.appendChild(seqDiv);
   chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
 }
@@ -3990,6 +3998,7 @@ function updateImagePreviewList(){
 // Append an AI image bubble to the chat
 function addImageChatBubble(url, altText="", title=""){
   const chatMessagesEl = document.getElementById("chatMessages");
+  const placeholderEl = document.getElementById("chatPlaceholder");
   if(!chatMessagesEl || !url) return;
 
   const seqDiv = document.createElement("div");
@@ -4024,6 +4033,7 @@ function addImageChatBubble(url, altText="", title=""){
   botDiv.appendChild(img);
 
   seqDiv.appendChild(botDiv);
+  if(placeholderEl) placeholderEl.style.display = "none";
   chatMessagesEl.appendChild(seqDiv);
   chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
 }


### PR DESCRIPTION
## Summary
- show `#chatPlaceholder` spinner in Aurora chat view
- hide the spinner when messages are loaded or added

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840d214ecd083239c9fb1b42934858d