### PR TITLE
Disable Chat Settings Save Button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -418,7 +418,7 @@
       </label>
     </div>
     <div class="modal-buttons">
-      <button id="chatSettingsSaveBtn">Save</button>
+      <button id="chatSettingsSaveBtn" disabled>Save</button>
       <button id="chatSettingsCancelBtn">Cancel</button>
     </div>
     <div class="modal-buttons">


### PR DESCRIPTION
## Summary
- disable the Save button in the Aurora chat settings modal so that it appears greyed out

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840d4386a54832380ee7c751515ba84