### PR TITLE
Show spinner while chat loads

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -213,7 +213,7 @@
       </div>
 
       <div id="chatMessages"></div>
-      <div id="chatPlaceholder" style="display:none;text-align:center;margin:1rem 0;">
+      <div id="chatPlaceholder" style="text-align:center;margin:1rem 0;">
         <span class="loading-spinner"></span>
       </div>
 

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2855,6 +2855,8 @@ btnNexumChat?.addEventListener("click", () => { window.location.href = btnNexumC
 btnNexumTabs?.addEventListener("click", () => { window.location.href = btnNexumTabs.dataset.url; });
 
 (async function init(){
+  const placeholderEl = document.getElementById("chatPlaceholder");
+  if(placeholderEl) placeholderEl.style.display = "";
   await loadSettings();
   await getSettings([
     "ai_model","last_chat_tab","last_sidebar_view",


### PR DESCRIPTION
## Summary
- show chat UI loading spinner by default
- reveal spinner when chat initialization begins

## Testing
- `npm run lint`
- `npm test` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_b_6840d3df924c83239c3c1e9c4feb5e04