### PR TITLE
Add model label to Aurora chat bubbles

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3195,6 +3195,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
         botBody.textContent = p.ai_text || "";
         botDiv.appendChild(botBody);
 
+
         if(p.token_info && showSubbubbleToken){
           try {
             const tInfo = JSON.parse(p.token_info);
@@ -3207,6 +3208,12 @@ async function loadChatHistory(tabId = 1, reset=false) {
             console.debug("[Server Debug] Could not parse token_info for prepended pair =>", e.message);
           }
         }
+
+        // Show model name at bottom-left of AI bubble
+        const modelDiv = document.createElement("div");
+        modelDiv.className = "model-indicator";
+        modelDiv.textContent = `${provider} / ${shortModel}`;
+        botDiv.appendChild(modelDiv);
 
         seqDiv.appendChild(botDiv);
         const pairDel = document.createElement("button");
@@ -3359,6 +3366,12 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
       console.debug("[Server Debug] Could not parse token_info for pair =>", pairId, e.message);
     }
   }
+
+  // Show model name at bottom-left of AI bubble
+  const modelDiv = document.createElement("div");
+  modelDiv.className = "model-indicator";
+  modelDiv.textContent = `${provider} / ${shortModel}`;
+  botDiv.appendChild(modelDiv);
 
   seqDiv.appendChild(botDiv);
 

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -618,6 +618,15 @@ body {
   margin-top: 10px;
 }
 
+/* Model name indicator in bottom-left corner of AI bubble */
+.model-indicator {
+  position: absolute;
+  left: 8px;
+  font-size: 0.75rem;
+  color: #aaa;
+  margin-top: 10px;
+}
+
 /* Additional styling for the new Chat Tabs sidebar panel */
 #sidebarViewChatTabs {
   margin-top: 1rem;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -618,6 +618,15 @@ body {
   margin-top: 10px;
 }
 
+/* Model name indicator in bottom-left corner of AI bubble */
+.model-indicator {
+  position: absolute;
+  left: 8px;
+  font-size: 0.75rem;
+  color: #aaa;
+  margin-top: 10px;
+}
+
 /* Additional styling for the new Chat Tabs sidebar panel */
 #sidebarViewChatTabs {
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- show the model used for an AI reply inside the chat bubble
- add CSS styling for the new model indicator

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6840d25eb8d48323927ec637b457d9da