### PR TITLE
Disable Feature Flags save button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -566,7 +566,7 @@
     <label><input type="checkbox" id="upArrowHistoryCheck" checked/> Enable Arrow Up history recall</label>
     <label><input type="checkbox" id="newTabProjectFlagCheck"/> Prompt for project name on New Tab</label>
     <div class="modal-buttons">
-      <button id="featureFlagsSaveBtn">Save</button>
+      <button id="featureFlagsSaveBtn" disabled>Save</button>
       <button id="featureFlagsCancelBtn">Cancel</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- disable the Feature Flags save button on the Aurora page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840d64aa1d88323ac2b4f526b59fdcf