### PR TITLE
Add screen launcher for run_full

### DIFF
--- a/run_full_prod.sh
+++ b/run_full_prod.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+SCREEN_NAME="auroraFULL"
+
+# Start a detached screen session and run the full stack
+screen -S "$SCREEN_NAME" -dm bash -c "./run_full.sh"
+


### PR DESCRIPTION
## Summary
- create `run_full_prod.sh` for launching the full Aurora stack inside a `screen` session

## Testing
- `npm run lint` in `Aurora`
- `npm run lint` in `Sterling` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840d747a8bc8323a8678a92ac411154