### PR TITLE
Add mobile sidebar auto-collapse

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -366,6 +366,20 @@ collapsedLogoEl?.addEventListener("click", () => {
   }
 });
 
+// On mobile viewports, collapse the sidebar when clicking
+// anywhere outside of it. This makes dismissing the sidebar
+// easier on touch devices without needing to tap the toggle
+// button again.
+document.addEventListener("click", ev => {
+  if(!isMobileViewport() || !sidebarVisible) return;
+  const sidebarEl = document.querySelector(".sidebar");
+  const dividerEl = document.getElementById("divider");
+  if(!sidebarEl) return;
+  if(!sidebarEl.contains(ev.target) && ev.target !== dividerEl && !dividerEl.contains(ev.target)){
+    toggleSidebar();
+  }
+});
+
 async function toggleNavMenu(){
   navMenuVisible = !navMenuVisible;
   toggleNavMenuVisibility(navMenuVisible);


### PR DESCRIPTION
## Summary
- collapse Aurora sidebar if mobile user clicks outside sidebar

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840d84679fc8323b93513ecfc6eac3e