### PR TITLE
Fix sidebar toggle event on mobile

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -349,18 +349,29 @@ async function toggleSidebar(){
   await setSetting("sidebar_visible", sidebarVisible);
 }
 const toggleSidebarBtn = $("#toggleSidebarBtn");
-toggleSidebarBtn?.addEventListener("click", toggleSidebar);
-document.getElementById("sidebarToggleIcon")?.addEventListener("click", toggleSidebar);
-document.getElementById("hideSidebarBtn")?.addEventListener("click", toggleSidebar);
+toggleSidebarBtn?.addEventListener("click", ev => {
+  ev.stopPropagation();
+  toggleSidebar();
+});
+document.getElementById("sidebarToggleIcon")?.addEventListener("click", ev => {
+  ev.stopPropagation();
+  toggleSidebar();
+});
+document.getElementById("hideSidebarBtn")?.addEventListener("click", ev => {
+  ev.stopPropagation();
+  toggleSidebar();
+});
 
-document.getElementById("expandSidebarBtn").addEventListener("click", () => {
+document.getElementById("expandSidebarBtn").addEventListener("click", ev => {
+  ev.stopPropagation();
   if(!sidebarVisible) {
     toggleSidebar();
   }
 });
 
 const collapsedLogoEl = document.getElementById("collapsedSidebarLogo");
-collapsedLogoEl?.addEventListener("click", () => {
+collapsedLogoEl?.addEventListener("click", ev => {
+  ev.stopPropagation();
   if(!sidebarVisible){
     toggleSidebar();
   }

--- a/Sterling/public/JS/sterlingMerged.js
+++ b/Sterling/public/JS/sterlingMerged.js
@@ -93,9 +93,14 @@ async function toggleSidebar(){
     body: JSON.stringify({ key: "sidebar_visible", value: sidebarVisible })
   });
 }
-$("#toggleSidebarBtn").addEventListener("click", toggleSidebar);
 
-document.getElementById("expandSidebarBtn").addEventListener("click", () => {
+$("#toggleSidebarBtn").addEventListener("click", ev => {
+  ev.stopPropagation();
+  toggleSidebar();
+});
+
+document.getElementById("expandSidebarBtn").addEventListener("click", ev => {
+  ev.stopPropagation();
   if(!sidebarVisible) {
     toggleSidebar();
   }


### PR DESCRIPTION
## Summary
- prevent double toggling when clicking sidebar controls on mobile

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840d9d56c088323b9a756725ae9a6aa