### PR TITLE
Add date headers and time-only chat timestamps

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -221,6 +221,14 @@ body {
   position: relative;
 }
 
+/* Date headers separating chat history by day */
+.date-header {
+  text-align: center;
+  margin: 10px 0;
+  font-weight: bold;
+  color: #aaa;
+}
+
 .delete-chat-btn {
   background: transparent;
   border: none;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -221,6 +221,14 @@ body {
   position: relative;
 }
 
+/* Date headers separating chat history by day */
+.date-header {
+  text-align: center;
+  margin: 10px 0;
+  font-weight: bold;
+  color: #555;
+}
+
 .delete-chat-btn {
   background: transparent;
   border: none;


### PR DESCRIPTION
## Summary
- update `formatTimestamp` to show only time
- insert date headers in chat history when the date changes
- style new date headers for dark/light modes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840d28869188323ac6acf35edb8a06b