### PR TITLE
Fix chat settings loader spinner

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -801,6 +801,7 @@ body {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
   align-items: center;
   justify-content: center;
 }

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -792,6 +792,25 @@ body {
   border-width: 3px;
 }
 
+/* Full page loader overlay */
+.page-loader {
+  display: none;
+  position: fixed;
+  z-index: 10002;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-loader.show {
+  display: flex;
+}
+
 .nav-placeholder {
   width: 100%;
   height: 1.2rem;


### PR DESCRIPTION
## Summary
- ensure the loading overlay uses a visible spinner
- port overlay styles to the light theme

## Testing
- `npm -C Aurora run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840df099bf08323b091e008237eefac