### PR TITLE
Add date headers and time-only timestamps in chat

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -297,6 +297,14 @@ body {
   font-size: 0.9rem;
 }
 
+/* Date header separating chat days */
+.chat-date-header {
+  text-align: center;
+  margin: 8px 0;
+  color: #aaa;
+  font-size: 0.8rem;
+}
+
 /* User bubble: displayed on the right side */
 .chat-user {
   background: #3b3b3b;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -298,6 +298,14 @@ body {
   font-size: 0.9rem;
 }
 
+/* Date header separating chat days */
+.chat-date-header {
+  text-align: center;
+  margin: 8px 0;
+  color: #666;
+  font-size: 0.8rem;
+}
+
 /* User bubble: displayed on the right side */
 .chat-user {
   background: #3b3b3b;


### PR DESCRIPTION
## Summary
- show time only in `formatTimestamp`
- inject date headers when chat date changes
- style the new headers for dark and light themes

## Testing
- `npm run lint` *(fails: `(no linter configured)`)*
- `npm run lint` in repo root *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6840e3665bec83239886f4367d8bab40