### PR TITLE
Reduce chat font size

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -341,7 +341,7 @@ body {
 /* Match font sizes between chat bubbles and input box */
 .chat-user,
 .chat-bot {
-  font-size: 1rem;
+  font-size: 0.95rem;
   position: relative;
   top: 10px;
 }
@@ -392,7 +392,7 @@ body {
   padding: 8px;
   flex: 1;
   outline: none;
-  font-size: 1rem;
+  font-size: 0.95rem;
   resize: none;
   min-height: 40px;
   overflow-y: auto;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -342,7 +342,7 @@ body {
 /* Match font sizes between chat bubbles and input box */
 .chat-user,
 .chat-bot {
-  font-size: 1rem;
+  font-size: 0.95rem;
   position: relative;
   top: 10px;
 }
@@ -393,7 +393,7 @@ body {
   padding: 8px;
   flex: 1;
   outline: none;
-  font-size: 1rem;
+  font-size: 0.95rem;
   resize: none;
   min-height: 40px;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- adjust chat message text size to 0.95rem

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6840e7154ee08323b3ce2d3391f2126f