### PR TITLE
Fix generated image display

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -145,9 +145,9 @@
     const origImg = document.createElement('img');
     const upscaledImg = document.createElement('img');
     const nobgImg = document.createElement('img');
-    origImg.style.maxWidth = '100%';
-    upscaledImg.style.maxWidth = '100%';
-    nobgImg.style.maxWidth = '100%';
+    origImg.style.maxWidth = '400px';
+    upscaledImg.style.maxWidth = '400px';
+    nobgImg.style.maxWidth = '400px';
     upscaledImg.style.display = 'none';
     nobgImg.style.display = 'none';
     container.appendChild(origImg);

--- a/Aurora/public/generated_images.html
+++ b/Aurora/public/generated_images.html
@@ -17,7 +17,8 @@
       gap:10px;
     }
     .grid img {
-      max-width:200px;
+      max-width:400px;
+      width:100%;
       border:1px solid #444;
     }
     a { color:#0ff; text-decoration:none; }

--- a/Aurora/public/image_generator.html
+++ b/Aurora/public/image_generator.html
@@ -25,7 +25,8 @@
       margin-top:1rem;
     }
     img {
-      max-width:100%;
+      max-width:400px;
+      width:100%;
       border:1px solid #444;
     }
   </style>


### PR DESCRIPTION
## Summary
- enforce 400px max-width for generated image previews

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6840e89a2d908323ae9037435ad95302