### PR TITLE
Remove provider from chat model display

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3300,7 +3300,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
         // Show model name at bottom-left of AI bubble
         const modelDiv = document.createElement("div");
         modelDiv.className = "model-indicator";
-        modelDiv.textContent = `${provider} / ${shortModel}`;
+        modelDiv.textContent = `${shortModel}`;
         botDiv.appendChild(modelDiv);
 
         seqDiv.appendChild(botDiv);
@@ -3470,7 +3470,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
   // Show model name at bottom-left of AI bubble
   const modelDiv = document.createElement("div");
   modelDiv.className = "model-indicator";
-  modelDiv.textContent = `${provider} / ${shortModel}`;
+  modelDiv.textContent = `${shortModel}`;
   botDiv.appendChild(modelDiv);
 
   seqDiv.appendChild(botDiv);
@@ -3493,7 +3493,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
 
     if (model) {
       const modelLabel = document.createElement("div");
-      modelLabel.textContent = `${provider} / ${model}`;
+      modelLabel.textContent = `${model}`;
       metaContainer.appendChild(modelLabel);
     }
 


### PR DESCRIPTION
## Summary
- clean up model indicator to omit provider name

## Testing
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm run lint` in `Aurora`
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm run lint` in `Sterling` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840ecae62b48323887b6b92fdabcc03