### PR TITLE
Add missing spinner style for chat settings loader

### DIFF
--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -792,6 +792,24 @@ body {
   border-width: 3px;
 }
 
+/* Full page loader overlay */
+.page-loader {
+  display: none;
+  position: fixed;
+  z-index: 10002;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+}
+
+.page-loader.show {
+  display: flex;
+}
+
 .nav-placeholder {
   width: 100%;
   height: 1.2rem;


### PR DESCRIPTION
## Summary
- ensure the loading overlay used when opening chat settings has the same spinner styling in the light theme

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6840e37655248323a0fbbf857c43f8e0