### PR TITLE
Set OpenRouter deepseek-chat default

### DIFF
--- a/Aurora/README.md
+++ b/Aurora/README.md
@@ -19,7 +19,7 @@ npm start
 | `GITHUB_REPO`    | Repository name.                                      |
 | `GITHUB_LABEL`   | (Optional) Issue label to filter on. If omitted, **all** open issues are returned. |
 | `OPENAI_API_KEY` | OpenAI API key for AI features ([get here](https://platform.openai.com/api-keys)) |
-| `OPENAI_MODEL`   | (Optional) Model ID for completions (default: gpt-4)  |
+| `OPENAI_MODEL`   | (Optional) Model ID for completions (default: deepseek/deepseek-chat)  |
 | `UPSCALE_SCRIPT_PATH` | (Optional) Path to the image upscale script. Defaults to the included loop.sh |
 | `PRINTIFY_SCRIPT_PATH` | (Optional) Path to the Printify submission script. Defaults to the included run.sh |
 | `STABLE_DIFFUSION_URL` | (Optional) Base URL for a self-hosted Stable Diffusion API |

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -119,8 +119,8 @@ const db = new TaskDB();
 console.debug("[Server Debug] Checking or setting default 'ai_model' in DB...");
 const currentModel = db.getSetting("ai_model");
 if (!currentModel) {
-  console.debug("[Server Debug] 'ai_model' is missing in DB, setting default to 'gpt-4.1-mini'.");
-  db.setSetting("ai_model", "gpt-4.1-mini");
+  console.debug("[Server Debug] 'ai_model' is missing in DB, setting default to 'deepseek/deepseek-chat'.");
+  db.setSetting("ai_model", "deepseek/deepseek-chat");
 } else {
   console.debug("[Server Debug] 'ai_model' found =>", currentModel);
 }
@@ -160,7 +160,7 @@ const jobManager = new JobManager();
  * Added checks to help diagnose missing or invalid API keys.
  */
 function getOpenAiClient() {
-  let service = db.getSetting("ai_service") || "openai";
+  let service = db.getSetting("ai_service") || "openrouter";
   const openAiKey = process.env.OPENAI_API_KEY || "";
   const openRouterKey = process.env.OPENROUTER_API_KEY || "";
 
@@ -1187,7 +1187,7 @@ app.post("/api/chat", async (req, res) => {
       finalUserMessage = `${prependInstr}\n\n${userMessage}`;
     }
 
-    const { provider } = parseProviderModel(model || "gpt-4.1-mini");
+    const { provider } = parseProviderModel(model || "deepseek/deepseek-chat");
     const systemContext = `System Context:\n${savedInstructions}\n\nModel: ${model} (provider: ${provider})\nUserTime: ${userTime}\nTimeZone: Central`;
 
     const conversation = [{ role: "system", content: systemContext }];
@@ -1225,7 +1225,7 @@ app.post("/api/chat", async (req, res) => {
     }
 
     function stripModelPrefix(m) {
-      if (!m) return "gpt-4.1-mini";
+      if (!m) return "deepseek/deepseek-chat";
       if (m.startsWith("openai/")) return m.substring("openai/".length);
       if (m.startsWith("openrouter/")) return m.substring("openrouter/".length);
       return m;

--- a/Sterling/alfe/Aurelix/dev/api_connector.js
+++ b/Sterling/alfe/Aurelix/dev/api_connector.js
@@ -11,7 +11,7 @@ const {
 } = require('../../../server_defs');
 
 // Default model
-const DEFAULT_AIMODEL = 'o3';
+const DEFAULT_AIMODEL = 'deepseek/deepseek-chat';
 
 /**
  * Provide a function to read global agent instructions from disk
@@ -135,7 +135,7 @@ router.post('/createChat', (req, res) => {
     agentInstructions: globalInstructions,
     attachedFiles: [],
     chatHistory: [],
-    aiProvider: 'openai',
+    aiProvider: 'openrouter',
     aiModel: DEFAULT_AIMODEL,
     pushAfterCommit: true
   };

--- a/Sterling/executable/server_webserver.js
+++ b/Sterling/executable/server_webserver.js
@@ -13,7 +13,7 @@ const { OpenAI } = require("openai");
 const app = express();
 
 const PROJECT_ROOT = path.resolve(__dirname, "..");
-const DEFAULT_AIMODEL = "o3";
+const DEFAULT_AIMODEL = "deepseek/deepseek-chat";
 
 /**
  * Global Agent Instructions

--- a/Sterling/executable/webserver/get_routes.js
+++ b/Sterling/executable/webserver/get_routes.js
@@ -95,7 +95,7 @@ function setupGetRoutes(deps) {
             agentInstructions: loadGlobalInstructions(),
             attachedFiles: [],
             chatHistory: [],
-            aiProvider: "openai",
+            aiProvider: "openrouter",
             aiModel: DEFAULT_AIMODEL,
             pushAfterCommit: true,
         };
@@ -115,7 +115,7 @@ function setupGetRoutes(deps) {
 
         /* defaults */
         chatData.aiModel = (chatData.aiModel || DEFAULT_AIMODEL).toLowerCase();
-        chatData.aiProvider = chatData.aiProvider || "openai";
+        chatData.aiProvider = chatData.aiProvider || "openrouter";
         chatData.additionalRepos = chatData.additionalRepos || [];
 
         const {

--- a/Sterling/executable/webserver/post_routes.js
+++ b/Sterling/executable/webserver/post_routes.js
@@ -130,7 +130,7 @@ function setupPostRoutes(deps) {
             }
 
             chatData.aiModel = (chatData.aiModel || DEFAULT_AIMODEL).toLowerCase();
-            chatData.aiProvider = chatData.aiProvider || "openai";
+            chatData.aiProvider = chatData.aiProvider || "openrouter";
 
             const repoCfg = loadSingleRepoConfig(repoName);
             if (!repoCfg) {

--- a/Sterling/fixMissingChunks/fixMissingChunks.js
+++ b/Sterling/fixMissingChunks/fixMissingChunks.js
@@ -43,9 +43,9 @@ const { execSync } = require('child_process');
 async function reconcileMissingChunksUsingAI(originalFileContent, newFileContent) {
   console.log("[DEBUG] reconcileMissingChunksUsingAI => Preparing request to AI API...");
   try {
-    const apiKey = process.env.OPENAI_API_KEY || 'your_openai_api_key';
-    const model = 'o3'; // updated to use "o3"
-    const endpoint = 'https://api.openai.com/v1/chat/completions';
+    const apiKey = process.env.OPENROUTER_API_KEY || 'your_openrouter_api_key';
+    const model = 'deepseek/deepseek-chat';
+    const endpoint = 'https://openrouter.ai/api/v1/chat/completions';
 
     const userPrompt = `
 We have two file versions:

--- a/example/alfe/Aurelix/dev/api_connector.js
+++ b/example/alfe/Aurelix/dev/api_connector.js
@@ -11,7 +11,7 @@ const {
 } = require('../../../server_defs');
 
 // Default model
-const DEFAULT_AIMODEL = 'o3';
+const DEFAULT_AIMODEL = 'deepseek/deepseek-chat';
 
 /**
  * Provide a function to read global agent instructions from disk
@@ -135,7 +135,7 @@ router.post('/createChat', (req, res) => {
     agentInstructions: globalInstructions,
     attachedFiles: [],
     chatHistory: [],
-    aiProvider: 'openai',
+    aiProvider: 'openrouter',
     aiModel: DEFAULT_AIMODEL,
     pushAfterCommit: true
   };

--- a/example/app/api/chat/route.ts
+++ b/example/app/api/chat/route.ts
@@ -20,38 +20,40 @@ export async function POST(req: NextRequest) {
     : [{ role: 'user', content: 'Say hello!' }];
 
   // 3. Make OpenAI API request with streaming enabled
-  const openAiKey = process.env.OPENAI_API_KEY || '';
-  if (!openAiKey) {
-    return new Response('[Error]: Missing OpenAI API key', { status: 500 });
+  const openRouterKey = process.env.OPENROUTER_API_KEY || '';
+  if (!openRouterKey) {
+    return new Response('[Error]: Missing OpenRouter API key', { status: 500 });
   }
 
   // Prepare chat completion payload
   const body = JSON.stringify({
-    model: 'gpt-4.1-mini',
+    model: 'deepseek/deepseek-chat',
     messages: userMessages,
     temperature: 0.7,
     stream: true
   });
 
-  // Forward request to OpenAI with fetch
-  const openAiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+  // Forward request to OpenRouter with fetch
+  const openRouterResponse = await fetch('https://openrouter.ai/api/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${openAiKey}`
+      Authorization: `Bearer ${openRouterKey}`,
+      'X-Title': 'MyAwesomeApp',
+      'HTTP-Referer': 'https://my-awesome-app.example.com'
     },
     body
   });
 
-  if (!openAiResponse.ok || !openAiResponse.body) {
-    return new Response('[Error]: OpenAI request failed', { status: 500 });
+  if (!openRouterResponse.ok || !openRouterResponse.body) {
+    return new Response('[Error]: OpenRouter request failed', { status: 500 });
   }
 
   // 4. Create a readable stream to transform OpenAI chunks to SSE format
   const readableStream = new ReadableStream({
     async start(controller) {
       // Use reader to read the response body
-      const reader = openAiResponse.body.getReader();
+      const reader = openRouterResponse.body.getReader();
       const decoder = new TextDecoder('utf-8');
       let done = false;
 


### PR DESCRIPTION
## Summary
- default to OpenRouter `deepseek/deepseek-chat`
- adjust server defaults for model and provider
- update API connector examples
- revise sample OpenRouter route
- document new default model

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6840f77cf9b8832389d01484e2575d3c