### PR TITLE
Update run_full_prod to display screen info

### DIFF
--- a/run_full_prod.sh
+++ b/run_full_prod.sh
@@ -12,3 +12,7 @@ fi
 
 # Start a detached screen session and run the full stack
 screen -S "$SCREEN_NAME" -dm bash -c "./run_full.sh"
+
+# Display information about the new screen session
+echo "Screen session started: $SCREEN_NAME"
+screen -ls | grep "$SCREEN_NAME"


### PR DESCRIPTION
## Summary
- output session info when starting `run_full_prod.sh`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684104710b6483238e2130038f32874f