### PR TITLE
Add short UUIDs for generated images

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -95,7 +95,7 @@
       <table id="secureFilesList" class="file-table">
         <thead>
           <tr>
-            <th data-col="id">#</th>
+            <th data-col="uuid">#</th>
             <th>Thumb</th>
             <th data-col="name">File</th>
             <th data-col="title">Title</th>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2428,7 +2428,7 @@ function renderFileList(){
     const tr = document.createElement("tr");
     tr.dataset.fileName = f.name;
     const tdIndex = document.createElement("td");
-    tdIndex.textContent = f.id ?? "";
+    tdIndex.textContent = f.uuid ?? f.id ?? "";
     const tdThumb = document.createElement("td");
     const thumbImg = document.createElement("img");
     thumbImg.src = `/uploads/${encodeURIComponent(f.name)}`;

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1635,9 +1635,10 @@ app.get("/api/upload/list", (req, res) => {
       const { size, mtime } = fs.statSync(path.join(uploadsDir, name));
       const title = db.getImageTitleForUrl(`/uploads/${name}`);
       const id = db.getImageIdForUrl(`/uploads/${name}`);
+      const uuid = db.getImageUuidForUrl(`/uploads/${name}`);
       const source = db.isGeneratedImage(`/uploads/${name}`) ? 'Generated' : 'Uploaded';
       const status = db.getImageStatusForUrl(`/uploads/${name}`) || (source === 'Generated' ? 'Generated' : 'Uploaded');
-      files.push({ id, name, size, mtime, title, source, status });
+      files.push({ id, uuid, name, size, mtime, title, source, status });
     }
     res.json(files);
   } catch (err) {


### PR DESCRIPTION
## Summary
- assign a short UUID when creating an image entry
- expose the UUID via `/api/upload/list`
- display the UUID instead of numeric ID in the sidebar image table

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841161c08bc83239839dbe616019723