### PR TITLE
Add global AI settings modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -149,6 +149,7 @@
       <a id="githubBtn" href="https://github.com/alfe-ai" target="_blank" class="top-btn">GitHub</a>
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings">⚙️</button>
+      <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="color:red;">⚙️</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 
@@ -435,6 +436,29 @@
     <div class="modal-buttons">
       <button id="chatSettingsBetaContinueBtn" disabled>Continue</button>
       <button id="chatSettingsBetaCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<div id="globalAiSettingsModal" class="modal">
+  <div class="modal-content">
+    <h2>Global AI Settings</h2>
+    <div style="margin-top:8px;">
+      <label>AI Service:
+        <select id="globalAiServiceSelect">
+          <option value="openai">OpenAI</option>
+          <option value="openrouter">OpenRouter</option>
+        </select>
+      </label>
+    </div>
+    <div style="margin-top:8px;">
+      <label>AI Model:
+        <select id="globalAiModelSelect"></select>
+      </label>
+    </div>
+    <div class="modal-buttons">
+      <button id="globalAiSettingsSaveBtn">Save</button>
+      <button id="globalAiSettingsCancelBtn">Cancel</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3922,6 +3922,46 @@ document.getElementById("taskListConfigCloseBtn").addEventListener("click", () =
 });
 
 // ----------------------------------------------------------------------
+// Global AI Settings modal
+// ----------------------------------------------------------------------
+async function openGlobalAiSettings(){
+  showPageLoader();
+  try {
+    const service = await getSetting("ai_service");
+    const resp = await fetch("/api/ai/models");
+    if(resp.ok){
+      const data = await resp.json();
+      const sel = document.getElementById("globalAiModelSelect");
+      sel.innerHTML = "";
+      (data.models || []).forEach(m => {
+        sel.appendChild(new Option(`${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`, m.id));
+      });
+      const curModel = await getSetting("ai_model");
+      if(curModel) sel.value = curModel;
+    }
+    document.getElementById("globalAiServiceSelect").value = service || "openrouter";
+  } catch(e){
+    console.error("Error opening global AI settings:", e);
+  } finally {
+    hidePageLoader();
+    showModal(document.getElementById("globalAiSettingsModal"));
+  }
+}
+
+async function saveGlobalAiSettings(){
+  const svc = document.getElementById("globalAiServiceSelect").value;
+  const model = document.getElementById("globalAiModelSelect").value;
+  await setSettings({ ai_service: svc, ai_model: model });
+  hideModal(document.getElementById("globalAiSettingsModal"));
+}
+
+document.getElementById("globalAiSettingsBtn").addEventListener("click", openGlobalAiSettings);
+document.getElementById("globalAiSettingsSaveBtn").addEventListener("click", saveGlobalAiSettings);
+document.getElementById("globalAiSettingsCancelBtn").addEventListener("click", () => {
+  hideModal(document.getElementById("globalAiSettingsModal"));
+});
+
+// ----------------------------------------------------------------------
 // Feature Flags modal
 // ----------------------------------------------------------------------
 async function loadFeatureFlags(){


### PR DESCRIPTION
## Summary
- add a red gear button in the top-right of the UI
- implement Global AI Settings modal to change default model/service

## Testing
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_b_68411886facc83238a95a0d5d0d6dcef