### PR TITLE
Add sorting arrows to uploader table

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2471,6 +2471,19 @@ function renderFileList(){
     tr.appendChild(tdAction);
     tbody.appendChild(tr);
   });
+  updateHeaderArrows();
+}
+
+function updateHeaderArrows(){
+  $$("#secureFilesList th").forEach(th => {
+    const col = th.dataset.col;
+    if(!col) return;
+    if(!th.dataset.label) th.dataset.label = th.textContent.trim();
+    th.textContent = th.dataset.label;
+    if(fileSortColumn === col){
+      th.textContent += fileSortAsc ? " \u25B2" : " \u25BC";
+    }
+  });
 }
 
 function setupFileSorting(){


### PR DESCRIPTION
## Summary
- show arrows for sorting direction in Secure Uploader file list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68411b11472c8323bccdcf8ef7da2ccf