### PR TITLE
Fix conflict by hiding Chat Settings button

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -148,12 +148,8 @@
 <!--    <a id="subscribeBtn" href="#" class="top-btn">Subscribe</a>-->
       <a id="githubBtn" href="https://github.com/alfe-ai" target="_blank" class="top-btn">GitHub</a>
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
-<<<<<<< HEAD
-      <button id="chatSettingsBtn" class="top-btn" title="Chat Settings">⚙️</button>
-      <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="color:red;">⚙️</button>
-=======
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
->>>>>>> origin/codex/hide-settings-gear-on-top-right
+      <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="color:red;">⚙️</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 


### PR DESCRIPTION
## Summary
- resolve merge conflict in `aurora.html`
- hide the original chat settings gear and keep the global AI settings gear visible

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm test` in `VMRunner` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68411c064f208323ac365e6b83f9a563