### PR TITLE
Default provider OpenRouter

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -388,7 +388,7 @@
       <label>AI Service:
         <select id="aiServiceSelect">
           <option value="openai">OpenAI</option>
-          <option value="openrouter">OpenRouter</option>
+          <option value="openrouter" selected>OpenRouter</option>
         </select>
       </label>
     </div>
@@ -447,7 +447,7 @@
       <label>AI Service:
         <select id="globalAiServiceSelect">
           <option value="openai">OpenAI</option>
-          <option value="openrouter">OpenRouter</option>
+          <option value="openrouter" selected>OpenRouter</option>
         </select>
       </label>
     </div>

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -125,6 +125,11 @@ if (!currentModel) {
   console.debug("[Server Debug] 'ai_model' found =>", currentModel);
 }
 
+console.debug("[Server Debug] Checking or setting default 'ai_service' in DB...");
+if (!db.getSetting("ai_service")) {
+  db.setSetting("ai_service", "openrouter");
+}
+
 // Theme setting for Nexum UI
 console.debug("[Server Debug] Checking or setting default theme settings in DB...");
 let themeColor = db.getSetting("nexum_theme_color");


### PR DESCRIPTION
## Summary
- default `ai_service` to openrouter in Aurora server
- choose OpenRouter by default in Aurora chat settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68411edfa2348323a51ad482886156c3