### PR TITLE
Switch default home page to Nexum UI

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2256,8 +2256,8 @@ app.get("/Image.html", (req, res) => {
 
 // Default landing page
 app.get("/", (req, res) => {
-  console.debug("[Server Debug] GET / => Serving aurora.html");
-  res.sendFile(path.join(__dirname, "../public/aurora.html"));
+  console.debug("[Server Debug] GET / => Serving nexum.html");
+  res.sendFile(path.join(__dirname, "../public/nexum.html"));
 });
 
 app.get("/beta", (req, res) => {
@@ -2268,8 +2268,8 @@ app.get("/beta", (req, res) => {
 app.use(express.static(path.join(__dirname, "../public")));
 
 app.get("/", (req, res) => {
-  console.debug("[Server Debug] GET / => Serving aurora.html");
-  res.sendFile(path.join(__dirname, "../public/aurora.html"));
+  console.debug("[Server Debug] GET / => Serving nexum.html");
+  res.sendFile(path.join(__dirname, "../public/nexum.html"));
 });
 
 app.get("/test_projects", (req, res) => {


### PR DESCRIPTION
## Summary
- update the root route in `server.js` so `/` serves `nexum.html`

## Testing
- `npm run lint` (no linter configured)
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68411f8b73708323ae23f129b764d6fc