### PR TITLE
Remove model tooltip from image chat bubbles

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4173,7 +4173,7 @@ function addImageChatBubble(url, altText="", title=""){
   const botHead = document.createElement("div");
   botHead.className = "bubble-header";
   botHead.innerHTML = `
-    <div class="name-oval name-oval-ai" title="${modelName}">${window.agentName}</div>
+    <div class="name-oval name-oval-ai">${window.agentName}</div>
     <span style="opacity:0.8;">${formatTimestamp(new Date().toISOString())}</span>
   `;
   const imgCopyBtn = document.createElement("button");


### PR DESCRIPTION
## Summary
- ensure hovering over Alfe's name on image pairs does not reveal the model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6841274459b08323878a6e0a9b30d6f6