### PR TITLE
Fix redirect when no active chats

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2281,7 +2281,10 @@ app.get("/Image.html", (req, res) => {
 app.get("/", (req, res) => {
   const sessionId = getSessionIdFromRequest(req);
   try {
-    if (!sessionId || db.listChatTabs(null, true, sessionId).length === 0) {
+    if (
+      !sessionId ||
+      db.listChatTabs(null, false, sessionId).length === 0
+    ) {
       console.debug("[Server Debug] GET / => Redirecting to nexum.html");
       return res.redirect("/nexum.html");
     }
@@ -2302,7 +2305,10 @@ app.use(express.static(path.join(__dirname, "../public")));
 app.get("/", (req, res) => {
   const sessionId = getSessionIdFromRequest(req);
   try {
-    if (!sessionId || db.listChatTabs(null, true, sessionId).length === 0) {
+    if (
+      !sessionId ||
+      db.listChatTabs(null, false, sessionId).length === 0
+    ) {
       console.debug("[Server Debug] GET / => Redirecting to nexum.html");
       return res.redirect("/nexum.html");
     }


### PR DESCRIPTION
## Summary
- redirect to Nexum start page when no unarchived chats remain

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684131e544d88323866d4daf7ffa5674