### PR TITLE
Add Bluesky link button in Aurora UI

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -147,6 +147,7 @@
 <!--    <span class="subscribe-teaser">Join the beta:</span>-->
 <!--    <a id="subscribeBtn" href="#" class="top-btn">Subscribe</a>-->
       <a id="githubBtn" href="https://github.com/alfe-ai" target="_blank" class="top-btn">GitHub</a>
+      <a id="blueskyBtn" href="https://bsky.app/profile/alfeai.bsky.social" target="_blank" class="top-btn" title="AlfeAI on Bluesky">🦋</a>
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>


### PR DESCRIPTION
## Summary
- add a Bluesky icon button linking to the AlfeAI profile

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684149d340a883238b38036c5319ef1f