### PR TITLE
Add favorite models modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -150,6 +150,7 @@
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>
+      <button id="favoriteModelsBtn" class="top-btn" title="Favorite Models">⭐</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 
@@ -459,6 +460,16 @@
     <div class="modal-buttons">
       <button id="globalAiSettingsSaveBtn">Save</button>
       <button id="globalAiSettingsCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<div id="favoriteModelsModal" class="modal">
+  <div class="modal-content">
+    <h2>Select Favorite Models</h2>
+    <div id="favoriteModelsContainer"></div>
+    <div class="modal-buttons">
+      <button id="favoriteModelsCloseBtn">Close</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1454,6 +1454,10 @@ document.getElementById("addModelModalAddBtn").addEventListener("click", async (
 document.getElementById("addModelModalCancelBtn").addEventListener("click", () => {
   hideModal(document.getElementById("addModelModal"));
 });
+document.getElementById("favoriteModelsBtn").addEventListener("click", openFavoriteModelsModal);
+document.getElementById("favoriteModelsCloseBtn").addEventListener("click", () => {
+  hideModal(document.getElementById("favoriteModelsModal"));
+});
 document.getElementById("newSubroutineBtn").addEventListener("click", addNewSubroutine);
 document.getElementById("viewActionHooksBtn").addEventListener("click", () => {
   renderActionHooks();
@@ -3752,6 +3756,51 @@ async function openAddModelModal(){
     }
   }
   showModal(document.getElementById("addModelModal"));
+}
+
+async function openFavoriteModelsModal(){
+  const container = document.getElementById("favoriteModelsContainer");
+  container.innerHTML = "Loading...";
+  showModal(document.getElementById("favoriteModelsModal"));
+  try {
+    const res = await fetch("/api/ai/models");
+    if(!res.ok){
+      container.textContent = "Error loading models";
+      return;
+    }
+    const data = await res.json();
+    const models = data.models || [];
+    let html = '<table style="width:100%;border-collapse:collapse;">'+
+               '<thead><tr><th>Fav</th><th>Model</th><th>Provider</th></tr></thead><tbody>';
+    models.forEach(m=>{
+      const starCls = m.favorite ? "favorite-star starred" : "favorite-star unstarred";
+      const starChar = m.favorite ? "★" : "☆";
+      html += `<tr><td><span class="${starCls}" data-id="${m.id}">${starChar}</span></td><td>${m.id}</td><td>${m.provider}</td></tr>`;
+    });
+    html += '</tbody></table>';
+    container.innerHTML = html;
+    container.querySelectorAll('.favorite-star').forEach(star=>{
+      star.addEventListener('click', async ()=>{
+        const modelId = star.dataset.id;
+        const newFav = !star.classList.contains('starred');
+        try{
+          const r = await fetch('/api/ai/favorites', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({ modelId, favorite:newFav })
+          });
+          if(r.ok){
+            star.classList.toggle('starred', newFav);
+            star.classList.toggle('unstarred', !newFav);
+            star.textContent = newFav ? '★' : '☆';
+          }
+        }catch(err){ console.error('Toggle favorite error', err); }
+      });
+    });
+  }catch(e){
+    console.error('Error loading favorites modal:', e);
+    container.textContent = 'Error loading models';
+  }
 }
 
 // Add a new model tab using given model id

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -540,6 +540,14 @@ body {
   font-size: 0.8rem;
 }
 
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.starred { color: gold; }
+.unstarred { color: #777; }
+
 /* Toggle icon in top-left corner */
 .nav-toggle-icon {
   position: absolute;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -543,6 +543,14 @@ body {
   font-size: 0.8rem;
 }
 
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.starred { color: gold; }
+.unstarred { color: #777; }
+
 /* Toggle icon in top-left corner */
 .nav-toggle-icon {
   position: absolute;


### PR DESCRIPTION
## Summary
- add Favorite Models button to aurora UI
- create modal for toggling favorite AI models
- style favorite star icons in both themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68414943fcd08323bb9e67d772e83282