### PR TITLE
Implement Nexum redirect when all tabs archived

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1250,6 +1250,9 @@ async function toggleArchiveTab(tabId, archived){
     renderSidebarTabs();
     renderArchivedSidebarTabs();
     updatePageTitle();
+    if(chatTabs.length > 0 && chatTabs.every(t => t.archived)){
+      location.href = '/nexum.html';
+    }
   }
 }
 async function selectTab(tabId){


### PR DESCRIPTION
## Summary
- update `toggleArchiveTab` to redirect to Nexum when no active tabs remain

## Testing
- `npm run lint --silent --prefix Aurora`

------
https://chatgpt.com/codex/tasks/task_b_6841514341c08323a7372bec6c89429b