### PR TITLE
Fix Aurora new tab behavior

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1194,12 +1194,10 @@ async function addNewTab(){
     body: JSON.stringify({ name:"", nexum: 0, project:"", type: tabType, sessionId })
   });
   if(r.ok){
+    const data = await r.json();
     hideModal($("#newTabModal"));
     await loadTabs();
-    renderTabs();
-    renderSidebarTabs();
-    renderArchivedSidebarTabs();
-    updatePageTitle();
+    await selectTab(data.id);
     // TODO: THIS WAS A TEMP FIX,
     // Reload the entire page so the new tab state is fully reflected
     // but only if this was the very first tab being created from the modal


### PR DESCRIPTION
## Summary
- switch to a newly created tab after it's made

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841532d942c8323a41cd6ce959cd286