### PR TITLE
Fix static file routing for chat pages

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2295,6 +2295,8 @@ app.get("/", (req, res) => {
   res.sendFile(path.join(__dirname, "../public/aurora.html"));
 });
 
+app.use(express.static(path.join(__dirname, "../public")));
+
 app.get("/beta", (req, res) => {
   console.debug("[Server Debug] GET /beta => Redirecting to home page");
   res.redirect("/");
@@ -2305,8 +2307,6 @@ app.get("/chat/:tabUuid", (req, res) => {
   console.debug(`[Server Debug] GET /chat/${req.params.tabUuid} => Serving aurora.html`);
   res.sendFile(path.join(__dirname, "../public/aurora.html"));
 });
-
-app.use(express.static(path.join(__dirname, "../public")));
 
 app.get("/", (req, res) => {
   const sessionId = getSessionIdFromRequest(req);


### PR DESCRIPTION
## Summary
- ensure Express serves static assets before dynamic /chat routes so `session.js` and `main.js` load correctly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684157f6f8f08323a75c8d76f995d2f2