### PR TITLE
Add Terms link to About page

### DIFF
--- a/Aurora/public/about.html
+++ b/Aurora/public/about.html
@@ -15,5 +15,7 @@
   <p>Alfe's roots are .. in 2022 with a task management prototype called Aurora [and an algorithmic trading proto called Alfheimr. The idea matured into Nexum, and by May 2025 we're focusing on integrating AI tools to streamline developer workflows.</p>
   lochner.tech
   njlochner.com
+  <hr>
+  <p>Read our <a href="terms.html" target="_blank">Terms of Service</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to `terms.html` from `about.html`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68415dfd2a14832385f58d978f8ab120