### PR TITLE
Fix sidebar top button visibility

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -343,6 +343,11 @@ async function toggleSidebar(){
     toggleSidebarBtnEl.textContent = sidebarVisible ? "Hide sidebar" : "Show sidebar";
   }
 
+  const topBtns = document.getElementById("topRightButtons");
+  if(topBtns){
+    topBtns.style.display = sidebarVisible ? "none" : "flex";
+  }
+
   const expandBtn = document.getElementById("expandSidebarBtn");
   expandBtn.style.display = sidebarVisible ? "none" : "block";
 
@@ -543,6 +548,10 @@ async function loadSettings(){
   const collapsedLogoInit = document.getElementById("collapsedSidebarLogo");
   if(collapsedLogoInit){
     collapsedLogoInit.style.display = sidebarVisible ? "none" : "block";
+  }
+  const initTopBtns = document.getElementById("topRightButtons");
+  if(initTopBtns){
+    initTopBtns.style.display = sidebarVisible ? "none" : "flex";
   }
   const appEl = document.querySelector(".app");
   if(appEl){


### PR DESCRIPTION
## Summary
- hide top-right buttons when the sidebar is opened

## Testing
- `npm -C Aurora run lint`
- `npm -C Aurora test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841cfee857483238f65191a61a6c4cd