### PR TITLE
Add AutoPR Node.js branch watcher

### DIFF
--- a/AutoPR/README.md
+++ b/AutoPR/README.md
@@ -1,0 +1,16 @@
+# AutoPR
+
+This simple Node.js project watches a git repository and prints any new remote branches that appear. It performs a `git fetch` periodically and compares the list of remote branches.
+
+## Usage
+
+1. Install dependencies (none are required, but this will generate a lock file):
+   ```bash
+   npm install
+   ```
+2. Run the watcher, passing the path to the repository. If no path is given, the current directory is used.
+   ```bash
+   node watchBranches.js /path/to/repo
+   ```
+
+The script checks for new branches every 10 seconds and logs them to the console.

--- a/AutoPR/package-lock.json
+++ b/AutoPR/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "AutoPR",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "AutoPR",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/AutoPR/package.json
+++ b/AutoPR/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "AutoPR",
+  "version": "1.0.0",
+  "description": "Watch a git repository for new remote branches",
+  "main": "watchBranches.js",
+  "scripts": {
+    "start": "node watchBranches.js",
+    "test": "echo 'No tests specified'"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/AutoPR/watchBranches.js
+++ b/AutoPR/watchBranches.js
@@ -1,0 +1,39 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+const repoPath = process.argv[2] || process.env.REPO_PATH || '.';
+const checkInterval = 10000; // 10 seconds
+
+let knownBranches = new Set();
+
+function fetchBranches() {
+  try {
+    execSync('git fetch', { cwd: repoPath, stdio: 'ignore' });
+    const result = execSync('git branch -r', { cwd: repoPath });
+    const branches = result.toString().split('\n').map(b => b.trim()).filter(b => b);
+    const newBranches = branches.filter(b => !knownBranches.has(b));
+    if (newBranches.length > 0) {
+      console.log('New branches found:');
+      newBranches.forEach(b => {
+        console.log('  ' + b);
+        knownBranches.add(b);
+      });
+    }
+  } catch (err) {
+    console.error('Error fetching branches:', err.message);
+  }
+}
+
+function init() {
+  try {
+    const result = execSync('git branch -r', { cwd: repoPath });
+    result.toString().split('\n').map(b => b.trim()).filter(b => b).forEach(b => knownBranches.add(b));
+  } catch (err) {
+    console.error('Failed to read initial branches:', err.message);
+    process.exit(1);
+  }
+  console.log(`Watching repository ${path.resolve(repoPath)} for new remote branches...`);
+  setInterval(fetchBranches, checkInterval);
+}
+
+init();


### PR DESCRIPTION
## Summary
- add new `AutoPR` folder with simple Node.js project
- project contains script `watchBranches.js` that prints new remote branches
- include documentation and package files

## Testing
- `npm install --package-lock-only`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841d8f139b88323839938ed571a50d7