### PR TITLE
Implement sign-up registration

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -151,6 +151,7 @@
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>
+      <button id="signupBtn" class="top-btn">Sign Up</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 
@@ -604,6 +605,23 @@
     <ul id="actionHooksList"></ul>
     <div class="modal-buttons">
       <button id="actionHooksCloseBtn">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Sign Up modal -->
+<div id="signupModal" class="modal">
+  <div class="modal-content">
+    <h2>Create Account</h2>
+    <label>Email:<br/>
+      <input type="email" id="signupEmail" style="width:100%;" />
+    </label>
+    <label style="margin-top:8px;">Password:<br/>
+      <input type="password" id="signupPassword" style="width:100%;" />
+    </label>
+    <div class="modal-buttons">
+      <button id="signupSubmitBtn">Register</button>
+      <button id="signupCancelBtn">Cancel</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1523,6 +1523,48 @@ if (subscribeCloseBtn) {
   );
 }
 
+const signupBtn = document.getElementById("signupBtn");
+if (signupBtn) {
+  signupBtn.addEventListener("click", e => {
+    e.preventDefault();
+    showModal(document.getElementById("signupModal"));
+  });
+}
+const signupCancelBtn = document.getElementById("signupCancelBtn");
+if (signupCancelBtn) {
+  signupCancelBtn.addEventListener("click", () =>
+    hideModal(document.getElementById("signupModal"))
+  );
+}
+const signupSubmitBtn = document.getElementById("signupSubmitBtn");
+if (signupSubmitBtn) {
+  signupSubmitBtn.addEventListener("click", async () => {
+    const email = document.getElementById("signupEmail").value.trim();
+    const password = document.getElementById("signupPassword").value;
+    if(!email || !password){
+      showToast("Email and password required");
+      return;
+    }
+    try {
+      const resp = await fetch("/api/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, sessionId })
+      });
+      const data = await resp.json().catch(() => null);
+      if(resp.ok && data && data.success){
+        showToast("Registered!");
+        hideModal(document.getElementById("signupModal"));
+      } else {
+        showToast(data?.error || "Registration failed");
+      }
+    } catch(err){
+      console.error("Registration failed", err);
+      showToast("Registration failed");
+    }
+  });
+}
+
 document.getElementById("viewTabChat").addEventListener("click", () => updateView('chat'));
 document.getElementById("viewTabTasks").addEventListener("click", () => updateView('tasks'));
 document.getElementById("viewTabArchive").addEventListener("click", () => updateView('archive'));


### PR DESCRIPTION
## Summary
- add a sign-up button in Aurora's top-right area
- implement sign-up modal and client logic
- create accounts table and helper methods in TaskDB
- hash passwords and add `/api/register` endpoint

## Testing
- `npm -s run lint --prefix Aurora`
- `node -e "require('./Aurora/src/taskDb.js')"` *(fails: cannot find module `better-sqlite3`)*

------
https://chatgpt.com/codex/tasks/task_b_6841d8b2cfd083239c8572259bca209d