### PR TITLE
Fix signup button persistence

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -31,6 +31,16 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
     .catch(err => console.error('Failed to fetch version', err));
+
+  const signupEl = document.getElementById('signupBtn');
+  if (signupEl) {
+    fetch('/api/account')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data && data.exists) signupEl.style.display = 'none';
+      })
+      .catch(err => console.error('Failed to fetch account', err));
+  }
 });
 
 let columnsOrder = [
@@ -1555,6 +1565,7 @@ if (signupSubmitBtn) {
       if(resp.ok && data && data.success){
         showToast("Registered!");
         hideModal(document.getElementById("signupModal"));
+        if(signupBtn) signupBtn.style.display = "none";
       } else {
         showToast(data?.error || "Registration failed");
       }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -834,6 +834,19 @@ app.post("/api/register", (req, res) => {
   }
 });
 
+app.get("/api/account", (req, res) => {
+  console.debug("[Server Debug] GET /api/account");
+  try {
+    const sessionId = getSessionIdFromRequest(req);
+    const account = sessionId ? db.getAccountBySession(sessionId) : null;
+    if (!account) return res.json({ exists: false });
+    res.json({ exists: true, id: account.id, email: account.email });
+  } catch(err) {
+    console.error("[TaskQueue] GET /api/account failed:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.get("/api/tasks/:id", (req, res) => {
   console.debug("[Server Debug] GET /api/tasks/:id =>", req.params.id);
   try {


### PR DESCRIPTION
## Summary
- hide signup button once account is created
- report account status via `/api/account`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841db3646f083238fa4ef9d0d52ec71