### PR TITLE
Allow sidebar open on swipe anywhere

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -437,7 +437,7 @@ document.addEventListener("touchend", ev => {
   const dy = Math.abs(ev.changedTouches[0].clientY - swipeStartY);
   const dt = Date.now() - swipeStartTime;
   if(dt <= swipeAllowedTime && Math.abs(dx) > swipeThreshold && Math.abs(dx) > dy){
-    if(dx > 0 && !sidebarVisible && swipeStartX < swipeEdgeSize && isMobileViewport()){
+    if(dx > 0 && !sidebarVisible && isMobileViewport()){
       toggleSidebar();
     } else if(dx < 0 && sidebarVisible){
       const sidebarEl = document.querySelector(".sidebar");


### PR DESCRIPTION
## Summary
- change mobile swipe logic in `Aurora/public/main.js` so that swiping right opens the sidebar from anywhere on the screen

## Testing
- `npm run lint` in `Aurora`
- `npm test` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841d97b9bf88323819fc2bef56e1fbe