### PR TITLE
Load most recent tab on home visit

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2281,12 +2281,30 @@ app.get("/Image.html", (req, res) => {
 app.get("/", (req, res) => {
   const sessionId = getSessionIdFromRequest(req);
   try {
-    if (
-      !sessionId ||
-      db.listChatTabs(null, false, sessionId).length === 0
-    ) {
+    if (!sessionId) {
       console.debug("[Server Debug] GET / => Redirecting to nexum.html");
       return res.redirect("/nexum.html");
+    }
+
+    const tabs = db.listChatTabs(null, false, sessionId);
+    if (tabs.length === 0) {
+      console.debug("[Server Debug] GET / => Redirecting to nexum.html");
+      return res.redirect("/nexum.html");
+    }
+
+    const lastTabId = db.getSetting("last_chat_tab");
+    let target = null;
+    if (typeof lastTabId !== "undefined") {
+      target = db.getChatTab(lastTabId, sessionId);
+    }
+    if (!target) {
+      target = tabs[0];
+    }
+    if (target && target.tab_uuid) {
+      console.debug(
+        `[Server Debug] GET / => Redirecting to last tab ${target.tab_uuid}`
+      );
+      return res.redirect(`/chat/${target.tab_uuid}`);
     }
   } catch (err) {
     console.error("[Server Debug] Error checking chat tabs:", err);
@@ -2308,22 +2326,6 @@ app.get("/chat/:tabUuid", (req, res) => {
   res.sendFile(path.join(__dirname, "../public/aurora.html"));
 });
 
-app.get("/", (req, res) => {
-  const sessionId = getSessionIdFromRequest(req);
-  try {
-    if (
-      !sessionId ||
-      db.listChatTabs(null, false, sessionId).length === 0
-    ) {
-      console.debug("[Server Debug] GET / => Redirecting to nexum.html");
-      return res.redirect("/nexum.html");
-    }
-  } catch (err) {
-    console.error("[Server Debug] Error checking chat tabs:", err);
-  }
-  console.debug("[Server Debug] GET / => Serving aurora.html");
-  res.sendFile(path.join(__dirname, "../public/aurora.html"));
-});
 
 app.get("/test_projects", (req, res) => {
   console.debug("[Server Debug] GET /test_projects => Serving test_projects.html");


### PR DESCRIPTION
## Summary
- redirect to the last used chat tab when visiting `/`
- remove duplicate root route in `server.js`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841d95770f08323bb23d5534df6db5d