### PR TITLE
Add clickable version tooltip

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -27,7 +27,19 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       if (data && data.version) {
         const vSpan = document.getElementById('versionSpan');
-        if (vSpan) vSpan.textContent = data.version;
+        if (vSpan) {
+          vSpan.textContent = data.version;
+          vSpan.addEventListener('click', () => {
+            fetch('/api/git-sha')
+              .then(r => r.ok ? r.json() : null)
+              .then(d => {
+                if (d && d.sha) {
+                  showToast(`Git SHA: ${d.sha}`, 3000);
+                }
+              })
+              .catch(err => console.error('Failed to fetch git sha', err));
+          });
+        }
       }
     })
     .catch(err => console.error('Failed to fetch version', err));

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2614,6 +2614,21 @@ app.get("/api/version", (req, res) => {
   }
 });
 
+app.get("/api/git-sha", (req, res) => {
+  try {
+    const sha = child_process
+      .execSync("git rev-parse HEAD", {
+        cwd: path.join(__dirname, ".."),
+      })
+      .toString()
+      .trim();
+    res.json({ sha });
+  } catch (err) {
+    console.error("[Server Debug] GET /api/git-sha =>", err);
+    res.status(500).json({ error: "Unable to determine git SHA" });
+  }
+});
+
 app.get("/api/tasklist/repo-path", (req, res) => {
   try {
     const gitUrl = db.getSetting("taskList_git_ssh_url");


### PR DESCRIPTION
## Summary
- expose the current git SHA via new `/api/git-sha` endpoint
- show git SHA in a toast when clicking the version number

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841e0a69bec8323b0f98b8c34922796