### PR TITLE
Add login modal and API

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -151,7 +151,7 @@
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>
-      <button id="signupBtn" class="top-btn">Sign Up</button>
+      <button id="signupBtn" class="top-btn">Sign Up/Login</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 
@@ -622,6 +622,24 @@
     <div class="modal-buttons">
       <button id="signupSubmitBtn">Register</button>
       <button id="signupCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<!-- Login modal -->
+<div id="loginModal" class="modal">
+  <div class="modal-content">
+    <h2>Login</h2>
+    <label>Email:<br/>
+      <input type="email" id="loginEmail" style="width:100%;" />
+    </label>
+    <label style="margin-top:8px;">Password:<br/>
+      <input type="password" id="loginPassword" style="width:100%;" />
+    </label>
+    <div class="modal-buttons">
+      <button id="loginSubmitBtn">Login</button>
+      <button id="loginSignupBtn">Sign Up</button>
+      <button id="loginCancelBtn">Cancel</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -205,6 +205,11 @@ function openSignupModal(e){
   showModal(document.getElementById("signupModal"));
 }
 
+function openLoginModal(e){
+  if(e) e.preventDefault();
+  showModal(document.getElementById("loginModal"));
+}
+
 function openAccountModal(e){
   if(e) e.preventDefault();
   if(accountInfo){
@@ -228,8 +233,8 @@ function updateAccountButton(info){
     btn.style.display = "inline-block";
   } else {
     accountInfo = null;
-    btn.textContent = "Sign Up";
-    btn.addEventListener("click", openSignupModal);
+    btn.textContent = "Sign Up/Login";
+    btn.addEventListener("click", openLoginModal);
   }
 }
 
@@ -1596,7 +1601,7 @@ if (subscribeCloseBtn) {
 
 const signupBtn = document.getElementById("signupBtn");
 if (signupBtn) {
-  signupBtn.addEventListener("click", openSignupModal);
+  signupBtn.addEventListener("click", openLoginModal);
 }
 const signupCancelBtn = document.getElementById("signupCancelBtn");
 if (signupCancelBtn) {
@@ -1630,6 +1635,51 @@ if (signupSubmitBtn) {
     } catch(err){
       console.error("Registration failed", err);
       showToast("Registration failed");
+    }
+  });
+}
+
+const loginCancelBtn = document.getElementById("loginCancelBtn");
+if (loginCancelBtn) {
+  loginCancelBtn.addEventListener("click", () =>
+    hideModal(document.getElementById("loginModal"))
+  );
+}
+
+const loginSignupBtn = document.getElementById("loginSignupBtn");
+if (loginSignupBtn) {
+  loginSignupBtn.addEventListener("click", () => {
+    hideModal(document.getElementById("loginModal"));
+    openSignupModal();
+  });
+}
+
+const loginSubmitBtn = document.getElementById("loginSubmitBtn");
+if (loginSubmitBtn) {
+  loginSubmitBtn.addEventListener("click", async () => {
+    const email = document.getElementById("loginEmail").value.trim();
+    const password = document.getElementById("loginPassword").value;
+    if(!email || !password){
+      showToast("Email and password required");
+      return;
+    }
+    try {
+      const resp = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, sessionId })
+      });
+      const data = await resp.json().catch(() => null);
+      if(resp.ok && data && data.success){
+        showToast("Logged in!");
+        hideModal(document.getElementById("loginModal"));
+        updateAccountButton({exists:true, id:data.id, email});
+      } else {
+        showToast(data?.error || "Login failed");
+      }
+    } catch(err){
+      console.error("Login failed", err);
+      showToast("Login failed");
     }
   });
 }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -834,6 +834,26 @@ app.post("/api/register", (req, res) => {
   }
 });
 
+app.post("/api/login", (req, res) => {
+  console.debug("[Server Debug] POST /api/login =>", req.body);
+  try {
+    const { email, password } = req.body;
+    const sessionId = req.body.sessionId || getSessionIdFromRequest(req);
+    if (!email || !password) {
+      return res.status(400).json({ error: "email and password required" });
+    }
+    const account = db.getAccountByEmail(email);
+    if (!account || !verifyPassword(password, account.password_hash)) {
+      return res.status(400).json({ error: "invalid credentials" });
+    }
+    db.setAccountSession(account.id, sessionId);
+    res.json({ success: true, id: account.id, email: account.email });
+  } catch (err) {
+    console.error("[TaskQueue] POST /api/login failed:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 app.get("/api/account", (req, res) => {
   console.debug("[Server Debug] GET /api/account");
   try {


### PR DESCRIPTION
## Summary
- extend server API with /api/login
- add Login modal and rename signup button to Sign Up/Login
- implement login logic in client script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841e67949d88323ae4e2865eb5fd6e1