### PR TITLE
Implement session merge on login

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1671,6 +1671,11 @@ if (loginSubmitBtn) {
       });
       const data = await resp.json().catch(() => null);
       if(resp.ok && data && data.success){
+        if(data.sessionId && data.sessionId !== sessionId){
+          sessionStorage.setItem('sessionId', data.sessionId);
+          setCookie('sessionId', data.sessionId);
+          setTimeout(() => location.reload(), 500);
+        }
         showToast("Logged in!");
         hideModal(document.getElementById("loginModal"));
         updateAccountButton({exists:true, id:data.id, email});

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -838,7 +838,7 @@ app.post("/api/login", (req, res) => {
   console.debug("[Server Debug] POST /api/login =>", req.body);
   try {
     const { email, password } = req.body;
-    const sessionId = req.body.sessionId || getSessionIdFromRequest(req);
+    let sessionId = req.body.sessionId || getSessionIdFromRequest(req);
     if (!email || !password) {
       return res.status(400).json({ error: "email and password required" });
     }
@@ -846,8 +846,14 @@ app.post("/api/login", (req, res) => {
     if (!account || !verifyPassword(password, account.password_hash)) {
       return res.status(400).json({ error: "invalid credentials" });
     }
+
+    if (account.session_id && account.session_id !== sessionId) {
+      db.mergeSessions(account.session_id, sessionId);
+      sessionId = account.session_id;
+    }
+
     db.setAccountSession(account.id, sessionId);
-    res.json({ success: true, id: account.id, email: account.email });
+    res.json({ success: true, id: account.id, email: account.email, sessionId });
   } catch (err) {
     console.error("[TaskQueue] POST /api/login failed:", err);
     res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## Summary
- merge session data when a user logs in
- reload client session if the server returns a new session id

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841eba358e08323b3d5f970b3ac8c80