### PR TITLE
Add Favorite Models modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -426,6 +426,7 @@
     </div>
     <div class="modal-buttons">
       <button id="featureFlagsBtn">Feature Flags</button>
+      <button id="favoriteModelsBtn">Favorite Models</button>
     </div>
   </div>
 </div>
@@ -605,6 +606,17 @@
     <ul id="actionHooksList"></ul>
     <div class="modal-buttons">
       <button id="actionHooksCloseBtn">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Favorite Models modal -->
+<div id="favoriteModelsModal" class="modal">
+  <div class="modal-content">
+    <h2>Favorite Models</h2>
+    <div id="favoriteModelsList"></div>
+    <div class="modal-buttons">
+      <button id="favoriteModelsCloseBtn">Close</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1572,6 +1572,10 @@ document.getElementById("addModelModalAddBtn").addEventListener("click", async (
 document.getElementById("addModelModalCancelBtn").addEventListener("click", () => {
   hideModal(document.getElementById("addModelModal"));
 });
+document.getElementById("favoriteModelsBtn").addEventListener("click", openFavoriteModelsModal);
+document.getElementById("favoriteModelsCloseBtn").addEventListener("click", () => {
+  hideModal(document.getElementById("favoriteModelsModal"));
+});
 document.getElementById("newSubroutineBtn").addEventListener("click", addNewSubroutine);
 document.getElementById("viewActionHooksBtn").addEventListener("click", () => {
   renderActionHooks();
@@ -3982,6 +3986,53 @@ async function openAddModelModal(){
     }
   }
   showModal(document.getElementById("addModelModal"));
+}
+
+async function openFavoriteModelsModal(){
+  const listEl = document.getElementById("favoriteModelsList");
+  if(listEl){
+    listEl.innerHTML = "<p>Loading...</p>";
+    try{
+      const r = await fetch("/api/ai/models");
+      if(r.ok){
+        const data = await r.json();
+        listEl.innerHTML = "";
+        (data.models||[]).forEach(m=>{
+          const row = document.createElement("div");
+          const star = document.createElement("span");
+          star.textContent = m.favorite ? "★" : "☆";
+          star.className = `favorite-star ${m.favorite ? "starred" : "unstarred"}`;
+          star.dataset.modelid = m.id;
+          star.addEventListener("click", async () => {
+            const newFav = !star.classList.contains("starred");
+            try {
+              const resp = await fetch("/api/ai/favorites", {
+                method:"POST",
+                headers:{"Content-Type":"application/json"},
+                body: JSON.stringify({ modelId: m.id, favorite: newFav })
+              });
+              if(resp.ok){
+                star.classList.toggle("starred", newFav);
+                star.classList.toggle("unstarred", !newFav);
+                star.textContent = newFav ? "★" : "☆";
+              }
+            } catch(e){ console.error("Error toggling favorite:",e); }
+          });
+          row.appendChild(star);
+          const txt = document.createElement("span");
+          txt.textContent = ` ${m.id} (${m.provider})`;
+          row.appendChild(txt);
+          listEl.appendChild(row);
+        });
+      } else {
+        listEl.textContent = "Error";
+      }
+    }catch(e){
+      console.error("Error loading models:", e);
+      listEl.textContent = "Error";
+    }
+  }
+  showModal(document.getElementById("favoriteModelsModal"));
 }
 
 // Add a new model tab using given model id

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -973,4 +973,17 @@ button:disabled {
   display: none !important;
 }
 
+/* Favorite star styling */
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.favorite-star.starred {
+  color: gold;
+}
+.favorite-star.unstarred {
+  color: #777;
+}
+
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -976,4 +976,17 @@ button:disabled {
   display: none !important;
 }
 
+/* Favorite star styling */
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.favorite-star.starred {
+  color: gold;
+}
+.favorite-star.unstarred {
+  color: #999;
+}
+
 


### PR DESCRIPTION
## Summary
- add 'Favorite Models' button in Chat Settings
- create modal to toggle favorite AI models
- style favorite star icons for light and dark themes

## Testing
- `npm test` (AutoPR)
- `npm test` (VMRunner) *(fails: no test specified)*
- `npm test` (AuroraMobile) *(fails: missing script)*
- `npm test` (Sterling) *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841ee08923c8323b2f6f4e1df74f752