### PR TITLE
Fix Aurora chat session persistence

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -879,7 +879,12 @@ app.post("/api/logout", (req, res) => {
     const sessionId = getSessionIdFromRequest(req);
     if (sessionId) {
       const account = db.getAccountBySession(sessionId);
-      if (account) db.setAccountSession(account.id, "");
+      // Preserve the account's session to allow chats to be restored on
+      // next login. Removing the session ID here prevents the user from
+      // recovering previous conversations after logging back in.
+      // The client clears its cookies, effectively logging out without
+      // deleting the stored session.
+      if (account) console.debug("[Server Debug] Keeping session", sessionId, "for account", account.id);
     }
     res.json({ success: true });
   } catch(err) {


### PR DESCRIPTION
## Summary
- keep account session on logout so chats remain tied to the user

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841eefe85d0832391ad2aa46e0140b1