### PR TITLE
Add compact sidebar with icons

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -49,6 +49,21 @@
         <li><button id="navNexumTabsBtn" class="tree-button" data-url="/nexum_tabs.html">Nexum Tabs</button></li>
       </ul>
     </nav>
+    <!-- Icon-only menu for collapsed sidebar -->
+    <nav class="icon-menu" style="display:none;">
+      <button id="navChatTabsIcon" class="icon-btn" title="Chats">💬</button>
+      <button id="navUploaderIcon" class="icon-btn" title="Images">🖼️</button>
+      <button id="navArchiveTabsIcon" class="icon-btn" title="Archived">📦</button>
+      <button id="navTasksIcon" class="icon-btn" title="Tasks">✅</button>
+      <button id="navFileTreeIcon" class="icon-btn" title="File Tree">📁</button>
+      <button id="navAiModelsIcon" class="icon-btn" title="AI Models">🤖</button>
+      <button id="navImageGeneratorIcon" class="icon-btn" title="Image Generator">🎨</button>
+      <button id="navJobsIcon" class="icon-btn" title="Jobs">💼</button>
+      <button id="navPipelineQueueIcon" class="icon-btn" title="Queue">📄</button>
+      <button id="navActivityIframeIcon" class="icon-btn" title="Activity">🌐</button>
+      <button id="navNexumChatIcon" class="icon-btn" title="Nexum Chat">✨</button>
+      <button id="navNexumTabsIcon" class="icon-btn" title="Nexum Tabs">🗂️</button>
+    </nav>
 
     <!-- Tasks view panel -->
     <div id="sidebarViewTasks">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -412,7 +412,7 @@ async function toggleSidebar(){
   sidebarVisible = !sidebarVisible;
   const sidebarEl = $(".sidebar");
   const dividerEl = $("#divider");
-  sidebarEl.style.display = sidebarVisible ? "" : "none";
+  sidebarEl.classList.toggle("collapsed", !sidebarVisible);
   dividerEl.style.display = sidebarVisible ? "" : "none";
   const toggleSidebarBtnEl = $("#toggleSidebarBtn");
   if(toggleSidebarBtnEl){
@@ -429,22 +429,18 @@ async function toggleSidebar(){
   }
 
   const expandBtn = document.getElementById("expandSidebarBtn");
-  expandBtn.style.display = sidebarVisible ? "none" : "block";
+  expandBtn.style.display = "none";
 
   const collapsedLogo = document.getElementById("collapsedSidebarLogo");
   if(collapsedLogo){
-    collapsedLogo.style.display = sidebarVisible ? "none" : "block";
+    collapsedLogo.style.display = "none";
   }
 
   // Shift top chat tabs bar when sidebar is collapsed so it doesn't
   // overlap the logo icon in the top left.
   const appEl = document.querySelector(".app");
   if(appEl){
-    if(sidebarVisible){
-      appEl.classList.remove("sidebar-collapsed");
-    } else {
-      appEl.classList.add("sidebar-collapsed");
-    }
+    appEl.classList.toggle("sidebar-collapsed", !sidebarVisible);
   }
 
   await setSetting("sidebar_visible", sidebarVisible);
@@ -618,16 +614,16 @@ async function loadSettings(){
   if(isMobileViewport()){
     sidebarVisible = false;
   }
-  $(".sidebar").style.display = sidebarVisible ? "" : "none";
+  $(".sidebar").classList.toggle("collapsed", !sidebarVisible);
   $("#divider").style.display = sidebarVisible ? "" : "none";
   const toggleSidebarBtn = $("#toggleSidebarBtn");
   if(toggleSidebarBtn){
     toggleSidebarBtn.textContent = sidebarVisible ? "Hide sidebar" : "Show sidebar";
   }
-  document.getElementById("expandSidebarBtn").style.display = sidebarVisible ? "none" : "block";
+  document.getElementById("expandSidebarBtn").style.display = "none";
   const collapsedLogoInit = document.getElementById("collapsedSidebarLogo");
   if(collapsedLogoInit){
-    collapsedLogoInit.style.display = sidebarVisible ? "none" : "block";
+    collapsedLogoInit.style.display = "none";
   }
   const initTopBtns = document.getElementById("topRightButtons");
   if(initTopBtns){
@@ -639,11 +635,7 @@ async function loadSettings(){
   }
   const appEl = document.querySelector(".app");
   if(appEl){
-    if(sidebarVisible){
-      appEl.classList.remove("sidebar-collapsed");
-    } else {
-      appEl.classList.add("sidebar-collapsed");
-    }
+    appEl.classList.toggle("sidebar-collapsed", !sidebarVisible);
   }
 
   if(typeof map.enter_submits_message !== "undefined"){
@@ -3165,6 +3157,19 @@ const btnJobs = document.getElementById("navJobsBtn");
 const btnPipelineQueue = document.getElementById("navPipelineQueueBtn");
 const btnNexumChat = document.getElementById("navNexumChatBtn");
 const btnNexumTabs = document.getElementById("navNexumTabsBtn");
+// Icon buttons for collapsed sidebar
+const btnTasksIcon = document.getElementById("navTasksIcon");
+const btnUploaderIcon = document.getElementById("navUploaderIcon");
+const btnChatTabsIcon = document.getElementById("navChatTabsIcon");
+const btnArchiveTabsIcon = document.getElementById("navArchiveTabsIcon");
+const btnFileTreeIcon = document.getElementById("navFileTreeIcon");
+const btnAiModelsIcon = document.getElementById("navAiModelsIcon");
+const btnImageGeneratorIcon = document.getElementById("navImageGeneratorIcon");
+const btnJobsIcon = document.getElementById("navJobsIcon");
+const btnPipelineQueueIcon = document.getElementById("navPipelineQueueIcon");
+const btnActivityIframeIcon = document.getElementById("navActivityIframeIcon");
+const btnNexumChatIcon = document.getElementById("navNexumChatIcon");
+const btnNexumTabsIcon = document.getElementById("navNexumTabsIcon");
 
 btnTasks.addEventListener("click", showTasksPanel);
 btnUploader.addEventListener("click", showUploaderPanel);
@@ -3184,6 +3189,24 @@ btnPipelineQueue?.addEventListener("click", () => {
 });
 btnNexumChat?.addEventListener("click", () => { window.location.href = btnNexumChat.dataset.url; });
 btnNexumTabs?.addEventListener("click", () => { window.location.href = btnNexumTabs.dataset.url; });
+
+// Icon button actions (expand sidebar then open panel or link)
+function openPanelWithSidebar(fn){
+  if(!sidebarVisible) toggleSidebar();
+  fn();
+}
+btnTasksIcon?.addEventListener("click", () => openPanelWithSidebar(showTasksPanel));
+btnUploaderIcon?.addEventListener("click", () => openPanelWithSidebar(showUploaderPanel));
+btnChatTabsIcon?.addEventListener("click", () => openPanelWithSidebar(showChatTabsPanel));
+btnArchiveTabsIcon?.addEventListener("click", () => openPanelWithSidebar(showArchiveTabsPanel));
+btnFileTreeIcon?.addEventListener("click", () => openPanelWithSidebar(showFileTreePanel));
+btnActivityIframeIcon?.addEventListener("click", () => openPanelWithSidebar(showActivityIframePanel));
+btnAiModelsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnAiModels.dataset.url; });
+btnImageGeneratorIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnImageGenerator.dataset.url; });
+btnJobsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); const url = btnJobs.dataset.url; window.open(url, "_blank"); });
+btnPipelineQueueIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); const url = btnPipelineQueue.dataset.url; window.open(url, "_blank"); });
+btnNexumChatIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumChat.dataset.url; });
+btnNexumTabsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumTabs.dataset.url; });
 
 (async function init(){
   const placeholderEl = document.getElementById("chatPlaceholder");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -489,6 +489,22 @@ body {
   margin-left: 60px;
 }
 
+/* Collapsed sidebar layout */
+.app.sidebar-collapsed .sidebar {
+  width: 60px !important;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.app.sidebar-collapsed .tree-menu,
+.app.sidebar-collapsed [id^="sidebarView"] {
+  display: none !important;
+}
+
+.app.sidebar-collapsed .icon-menu {
+  display: block;
+}
+
 /* Icon displayed before chat tab names */
 #tabsContainer .tab-icon,
 #verticalTabsContainer .tab-icon {
@@ -886,6 +902,34 @@ body {
 }
 
 .tree-button.active {
+  background: #555;
+  border-color: #888;
+  color: #fff;
+}
+
+/* Icon menu for collapsed sidebar */
+.icon-menu {
+  display: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+.icon-btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  background: #333;
+  border: 1px solid #444;
+  color: #ddd;
+  padding: 6px 0;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  text-decoration: none;
+}
+
+.icon-btn.active {
   background: #555;
   border-color: #888;
   color: #fff;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -492,6 +492,22 @@ body {
   margin-left: 60px;
 }
 
+/* Collapsed sidebar layout */
+.app.sidebar-collapsed .sidebar {
+  width: 60px !important;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.app.sidebar-collapsed .tree-menu,
+.app.sidebar-collapsed [id^="sidebarView"] {
+  display: none !important;
+}
+
+.app.sidebar-collapsed .icon-menu {
+  display: block;
+}
+
 /* Icon displayed before chat tab names */
 #tabsContainer .tab-icon,
 #verticalTabsContainer .tab-icon {
@@ -892,6 +908,34 @@ body {
   background: #ccc;
   border-color: #bbb;
   color: #fff;
+}
+
+/* Icon menu for collapsed sidebar */
+.icon-menu {
+  display: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+.icon-btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  background: #ddd;
+  border: 1px solid #bbb;
+  color: #333;
+  padding: 6px 0;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  text-decoration: none;
+}
+
+.icon-btn.active {
+  background: #ccc;
+  border-color: #888;
+  color: #000;
 }
 
 /* Version info in sidebar */


### PR DESCRIPTION
## Summary
- implement an icon-based navigation bar that appears when the sidebar is collapsed
- hide text views and shrink sidebar width in collapsed mode
- add styles for the new icon menu in both light and dark themes
- update JS logic to toggle collapsed class and handle icon actions

## Testing
- `npm run lint` in `Aurora` *(no linter configured)*
- `npm run lint` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6841f66cf4388323a6d81ae3561bcfec