### PR TITLE
Fix duplicate login modal on account button

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -226,6 +226,7 @@ function updateAccountButton(info){
   if(!btn) return;
   btn.removeEventListener("click", openSignupModal);
   btn.removeEventListener("click", openAccountModal);
+  btn.removeEventListener("click", openLoginModal);
   if(info && info.exists){
     accountInfo = info;
     btn.textContent = "Account";


### PR DESCRIPTION
## Summary
- remove existing login modal event when applying account logic

## Testing
- `npm run lint` in `Aurora`
- `npm test` in `Sterling`
- `npm run lint` in `Sterling`

------
https://chatgpt.com/codex/tasks/task_b_6841f7950cf08323a16eb40ceab9cde6