### PR TITLE
Thin sidebar tweaks

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -486,12 +486,12 @@ body {
 
 /* When sidebar is collapsed, shift the chat tabs bar to clear the logo */
 .app.sidebar-collapsed #chatTabs {
-  margin-left: 60px;
+  margin-left: 50px;
 }
 
 /* Collapsed sidebar layout */
 .app.sidebar-collapsed .sidebar {
-  width: 60px !important;
+  width: 50px !important;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
@@ -612,6 +612,12 @@ body {
   font-size: 0.7rem;
   color: #aaa;
   z-index: 1000;
+}
+
+/* Hide counters when sidebar is collapsed */
+.app.sidebar-collapsed #imageLimitInfo,
+.app.sidebar-collapsed #imageLimitCountdown {
+  display: none !important;
 }
 
 /* Button to hide the sidebar */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -489,12 +489,12 @@ body {
 
 /* When sidebar is collapsed, shift the chat tabs bar to clear the logo */
 .app.sidebar-collapsed #chatTabs {
-  margin-left: 60px;
+  margin-left: 50px;
 }
 
 /* Collapsed sidebar layout */
 .app.sidebar-collapsed .sidebar {
-  width: 60px !important;
+  width: 50px !important;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
 }
@@ -615,6 +615,12 @@ body {
   font-size: 0.7rem;
   color: #aaa;
   z-index: 1000;
+}
+
+/* Hide counters when sidebar is collapsed */
+.app.sidebar-collapsed #imageLimitInfo,
+.app.sidebar-collapsed #imageLimitCountdown {
+  display: none !important;
 }
 
 /* Button to hide the sidebar */


### PR DESCRIPTION
## Summary
- tweak collapsed sidebar width to 50px
- hide the image counters when the sidebar is collapsed

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841f892e8a48323af25cb42fce1accc