### PR TITLE
Fix mobile viewport height

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -19,7 +19,8 @@ body {
 /* App layout: sidebar + main chat panel */
 .app {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
+  height: 100dvh;
   overflow: hidden; /* Restored overflow hidden to allow separate scrolling areas */
   position: relative; /* For absolute positioning of exclamation icon */
 }


### PR DESCRIPTION
## Summary
- ensure the main app uses `100dvh` with a fallback `min-height: 100vh`

## Testing
- `npm test` in `AutoPR`

------
https://chatgpt.com/codex/tasks/task_b_6841f807212c8323968c242939c55e09