### PR TITLE
Fix chat input covered on mobile

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -19,7 +19,7 @@ body {
 /* App layout: sidebar + main chat panel */
 .app {
   display: flex;
-  min-height: 100vh;
+  min-height: 100dvh;
   height: 100dvh;
   overflow: hidden; /* Restored overflow hidden to allow separate scrolling areas */
   position: relative; /* For absolute positioning of exclamation icon */
@@ -411,6 +411,7 @@ body {
   margin-top: 0.5rem;
   width: 100%;
   flex: 0 0 auto;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .chat-input-container textarea {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -21,7 +21,8 @@ body {
 /* App layout: sidebar + main chat panel */
 .app {
   display: flex;
-  height: 100vh;
+  min-height: 100dvh;
+  height: 100dvh;
   overflow: hidden; /* Restored overflow hidden to allow separate scrolling areas */
   position: relative; /* For absolute positioning of exclamation icon */
 }
@@ -413,6 +414,7 @@ body {
   margin-top: 0.5rem;
   width: 100%;
   flex: 0 0 auto;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .chat-input-container textarea {


### PR DESCRIPTION
## Summary
- fix mobile viewport for `.app` container
- account for safe-area in chat input container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6841faa577848323bac140f05acafb3f