### PR TITLE
Increase sidebar icon size

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -589,7 +589,7 @@ body {
   position: absolute;
   top: 8px;
   right: 8px;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: #888;
   cursor: pointer;
   user-select: none;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -592,7 +592,7 @@ body {
   position: absolute;
   top: 8px;
   right: 8px;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: #888;
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
## Summary
- adjust `.close-sidebar-icon` font size to 1.5rem for better visibility

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6841fc5f17a88323bfbb8d655e632140