### PR TITLE
Update image rendering width

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3643,7 +3643,8 @@ async function loadChatHistory(tabId = 1, reset=false) {
           img.src = p.image_url;
           img.alt = p.image_alt || "";
           if(p.image_title) img.title = p.image_title;
-          img.style.maxWidth = "400px";
+          img.style.maxWidth = "100%";
+          img.style.height = "auto";
           botDiv.appendChild(img);
         }
 
@@ -3817,7 +3818,8 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
     img.src = imageUrl;
     img.alt = imageAlt;
     if(imageTitle) img.title = imageTitle;
-    img.style.maxWidth = "400px";
+    img.style.maxWidth = "100%";
+    img.style.height = "auto";
     botDiv.appendChild(img);
   }
 
@@ -4551,7 +4553,8 @@ function addImageChatBubble(url, altText="", title=""){
   img.src = url;
   img.alt = altText;
   if(title) img.title = title;
-  img.style.maxWidth = "400px";
+  img.style.maxWidth = "100%";
+  img.style.height = "auto";
   img.addEventListener('load', scrollChatToBottom);
   botDiv.appendChild(img);
 
@@ -4646,7 +4649,7 @@ registerActionHook("embedMockImages", async ({response}) => {
       });
       const data = await r.json();
       if(r.ok && data.url){
-        const imgTag = `<img src="${data.url}" alt="${alt}" style="max-width:400px;">`;
+        const imgTag = `<img src="${data.url}" alt="${alt}" style="max-width:100%;height:auto;">`;
         html = html.replace(placeholder, imgTag);
         updateImageLimitInfo();
       }

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -366,6 +366,13 @@ body {
   font-family: monospace;      /* Changed to monospaced */
 }
 
+/* Ensure images fit within chat bubbles */
+.chat-user img,
+.chat-bot img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Match font sizes between chat bubbles and input box */
 .chat-user,
 .chat-bot {

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -369,6 +369,13 @@ body {
   font-family: monospace;      /* Changed to monospaced */
 }
 
+/* Ensure images fit within chat bubbles */
+.chat-user img,
+.chat-bot img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Match font sizes between chat bubbles and input box */
 .chat-user,
 .chat-bot {


### PR DESCRIPTION
## Summary
- constrain generated images to the chat bubble width in Aurora
- ensure CSS limits images within bubbles in both themes

## Testing
- `npm test` *(fails: package.json missing)*
- `cd Aurora && npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6841fdc8fbc88323a4067344ce286841