### PR TITLE
Add thin sidebar icons

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -175,6 +175,11 @@
     Show Sidebar
   </div>
   <img id="collapsedSidebarLogo" src="/alfe_favicon_64x64.ico" title="Expand sidebar" alt="Alfe AI logo" style="height:32px; position:absolute; top:8px; left:8px; cursor:pointer; display:none; z-index:1000;"/>
+  <div id="thinSidebar" class="thin-sidebar">
+    <button id="thinIconChats" class="thin-icon" title="Chats">💬</button>
+    <button id="thinIconImages" class="thin-icon" title="Images">🖼️</button>
+    <button id="thinIconArchived" class="thin-icon" title="Archived">📦</button>
+  </div>
 
   <main class="chat-panel">
     <div id="viewTabsBar" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;" hidden>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3246,6 +3246,10 @@ const btnPipelineQueueIcon = document.getElementById("navPipelineQueueIcon");
 const btnActivityIframeIcon = document.getElementById("navActivityIframeIcon");
 const btnNexumChatIcon = document.getElementById("navNexumChatIcon");
 const btnNexumTabsIcon = document.getElementById("navNexumTabsIcon");
+// Thin sidebar icons
+const thinChatIcon = document.getElementById("thinIconChats");
+const thinImagesIcon = document.getElementById("thinIconImages");
+const thinArchiveIcon = document.getElementById("thinIconArchived");
 
 btnTasks.addEventListener("click", showTasksPanel);
 btnUploader.addEventListener("click", showUploaderPanel);
@@ -3283,6 +3287,10 @@ btnJobsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar
 btnPipelineQueueIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); const url = btnPipelineQueue.dataset.url; window.open(url, "_blank"); });
 btnNexumChatIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumChat.dataset.url; });
 btnNexumTabsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumTabs.dataset.url; });
+// Thin sidebar icon actions
+thinChatIcon?.addEventListener("click", () => openPanelWithSidebar(showChatTabsPanel));
+thinImagesIcon?.addEventListener("click", () => openPanelWithSidebar(showUploaderPanel));
+thinArchiveIcon?.addEventListener("click", () => openPanelWithSidebar(showArchiveTabsPanel));
 
 (async function init(){
   const placeholderEl = document.getElementById("chatPlaceholder");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -965,6 +965,33 @@ body {
   color: #fff;
 }
 
+/* Thin sidebar shown when main sidebar is collapsed */
+.thin-sidebar {
+  position: absolute;
+  top: 60px;
+  left: 8px;
+  width: 36px;
+  background: #2d2d2d;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 4px 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  z-index: 1001;
+}
+.app.sidebar-collapsed .thin-sidebar {
+  display: flex;
+}
+.thin-sidebar .thin-icon {
+  background: none;
+  border: none;
+  color: #ddd;
+  font-size: 1.2rem;
+  margin: 4px 0;
+  cursor: pointer;
+}
+
 /* Version info in sidebar */
 .version-info {
   font-size: 0.75rem;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -968,6 +968,33 @@ body {
   color: #000;
 }
 
+/* Thin sidebar shown when main sidebar is collapsed */
+.thin-sidebar {
+  position: absolute;
+  top: 60px;
+  left: 8px;
+  width: 36px;
+  background: #eee;
+  border: 1px solid #bbb;
+  border-radius: 8px;
+  padding: 4px 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  z-index: 1001;
+}
+.app.sidebar-collapsed .thin-sidebar {
+  display: flex;
+}
+.thin-sidebar .thin-icon {
+  background: none;
+  border: none;
+  color: #333;
+  font-size: 1.2rem;
+  margin: 4px 0;
+  cursor: pointer;
+}
+
 /* Version info in sidebar */
 .version-info {
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- show a small vertical bar when the sidebar is collapsed
- add buttons for Chats, Images, and Archived in that bar
- expand the sidebar and switch tabs when those thin buttons are clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68420061bac48323bfd64cdaf1a390b4