### PR TITLE
Hide top chat tabs bar

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -393,7 +393,8 @@
     <br/>
     <label><input type="checkbox" id="showNavMenuCheck" checked/> Show navigation menu</label>
     <br/>
-    <label><input type="checkbox" id="showTopChatTabsCheck"/> Show top chat tabs bar</label>
+    <!-- Top chat tabs are always hidden; hide this setting -->
+    <label style="display:none;"><input type="checkbox" id="showTopChatTabsCheck"/> Show top chat tabs bar</label>
     <br/>
     <label><input type="checkbox" id="showViewTabsBarCheck"/> Show view tabs bar</label>
     <br/>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -690,9 +690,8 @@ async function loadSettings(){
   if(newBtn) newBtn.style.display = modelTabsBarVisible ? "" : "none";
   if(toggleBtn) toggleBtn.textContent = modelTabsBarVisible ? "Hide Models" : "Models";
 
-  if(typeof map.top_chat_tabs_bar_visible !== "undefined"){
-    topChatTabsBarVisible = map.top_chat_tabs_bar_visible !== false;
-  }
+  // Force the top chat tabs bar to remain hidden regardless of saved setting
+  topChatTabsBarVisible = false;
   toggleTopChatTabsVisibility(topChatTabsBarVisible);
 
   if(typeof map.project_info_bar_visible !== "undefined"){


### PR DESCRIPTION
## Summary
- hide the Show top chat tabs bar checkbox
- always set topChatTabsBarVisible to `false`

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_684202d8168c832389665b8c7fb9b201