### PR TITLE
Fix thin sidebar icons

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3271,8 +3271,8 @@ btnNexumChat?.addEventListener("click", () => { window.location.href = btnNexumC
 btnNexumTabs?.addEventListener("click", () => { window.location.href = btnNexumTabs.dataset.url; });
 
 // Icon button actions (expand sidebar then open panel or link)
-function openPanelWithSidebar(fn){
-  if(!sidebarVisible) toggleSidebar();
+async function openPanelWithSidebar(fn){
+  if(!sidebarVisible) await toggleSidebar();
   fn();
 }
 btnTasksIcon?.addEventListener("click", () => openPanelWithSidebar(showTasksPanel));


### PR DESCRIPTION
## Summary
- ensure `openPanelWithSidebar` awaits sidebar toggle before switching views

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6842050c86748323b7dab13252257abc