### PR TITLE
Fix: hide account id in account modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -675,7 +675,6 @@
   <div class="modal-content">
     <h2>Account</h2>
     <p>Email: <span id="accountEmail"></span></p>
-    <p>ID: <span id="accountId"></span></p>
     <div id="totpSection" style="margin-top:10px;">
       <button id="enableTotpBtn">Enable 2FA</button>
       <div id="totpSetup" style="display:none; margin-top:10px;">

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -227,9 +227,7 @@ function openAccountModal(e){
   if(e) e.preventDefault();
   if(accountInfo){
     const emailEl = document.getElementById("accountEmail");
-    const idEl = document.getElementById("accountId");
     if(emailEl) emailEl.textContent = accountInfo.email;
-    if(idEl) idEl.textContent = accountInfo.id;
     const enabledMsg = document.getElementById('totpEnabledMsg');
     const enableBtn = document.getElementById('enableTotpBtn');
     if(accountInfo.totpEnabled){


### PR DESCRIPTION
## Summary
- remove account ID from the account modal
- clean up JS handler for account details

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68420a8944248323a9b6ed8919778f1a