### PR TITLE
Fix null reference for optional scroll button

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1912,11 +1912,13 @@ setLoopUi(imageLoopEnabled);
 let inputHistory = [];
 let inputHistoryPos = -1;
 
-scrollDownBtnEl.addEventListener("click", ()=>{
-  const chatMessagesEl = document.getElementById("chatMessages");
-  chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
-  setTimeout(scrollChatToBottom, 0);
-});
+if (scrollDownBtnEl) {
+  scrollDownBtnEl.addEventListener("click", () => {
+    const chatMessagesEl = document.getElementById("chatMessages");
+    chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+    setTimeout(scrollChatToBottom, 0);
+  });
+}
 
 chatInputEl.addEventListener("keydown", (e) => {
   if (upArrowHistoryEnabled && e.key === "ArrowUp") {


### PR DESCRIPTION
## Summary
- avoid adding an event listener when `#scrollDownBtn` is missing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68420b37c2bc8323bba8959513381d69