### PR TITLE
Remove email from chat history display

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2046,7 +2046,7 @@ chatSendBtnEl.addEventListener("click", async () => {
   const userHead = document.createElement("div");
   userHead.className = "bubble-header";
   const userTime = new Date().toISOString();
-  const userLabel = accountInfo?.email || "User";
+  const userLabel = "You";
   userHead.innerHTML = `
     <div class="name-oval name-oval-user">${userLabel}</div>
     <span style="opacity:0.8;">${formatTimestamp(userTime)}</span>
@@ -3584,7 +3584,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
           {
             const userHead = document.createElement("div");
             userHead.className = "bubble-header";
-            const userLabel = accountInfo?.email || "User";
+            const userLabel = "You";
             userHead.innerHTML = `
               <div class="name-oval name-oval-user">${userLabel}</div>
               <span style="opacity:0.8;">${formatTimestamp(p.timestamp)}</span>
@@ -3756,7 +3756,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
     {
       const userHead = document.createElement("div");
       userHead.className = "bubble-header";
-      const userLabel = accountInfo?.email || "User";
+      const userLabel = "You";
       userHead.innerHTML = `
         <div class="name-oval name-oval-user">${userLabel}</div>
         <span style="opacity:0.8;">${formatTimestamp(userTs)}</span>


### PR DESCRIPTION
## Summary
- hide the logged-in email and show "You" for chat messages in Aurora

## Testing
- `npm run lint` in `Aurora/` (no linter configured)
- `npm test` in `Aurora/` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_6842101480d48323b179742324e75ea1