### PR TITLE
Fix collapsed sidebar icon visibility

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -607,6 +607,11 @@ body {
   display: none;
 }
 
+/* Hide large toggle icon when sidebar is collapsed */
+.app.sidebar-collapsed #sidebarToggleIcon {
+  display: none;
+}
+
 /* Display session ID next to the sidebar icon */
 #sessionIdText.session-id {
   display: none;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -610,6 +610,11 @@ body {
   display: none;
 }
 
+/* Hide large toggle icon when sidebar is collapsed */
+.app.sidebar-collapsed #sidebarToggleIcon {
+  display: none;
+}
+
 /* Display session ID next to the sidebar icon */
 #sessionIdText.session-id {
   display: none;


### PR DESCRIPTION
## Summary
- hide the main sidebar toggle icon when the sidebar is collapsed

## Testing
- `npm run lint`
- `npm test` (fails: Missing script)
- `npm test` in AutoPR (prints `No tests specified`)

------
https://chatgpt.com/codex/tasks/task_b_684210d3a55c8323aff71d1c80986eed