### PR TITLE
Add privacy policy page and link from about page

### DIFF
--- a/Aurora/public/about.html
+++ b/Aurora/public/about.html
@@ -16,6 +16,7 @@
   lochner.tech
   njlochner.com
   <hr>
-  <p>Read our <a href="terms.html" target="_blank">Terms of Service</a>.</p>
+  <p>Read our <a href="terms.html" target="_blank">Terms of Service</a> and
+  <a href="privacy.html" target="_blank">Privacy Policy</a>.</p>
 </body>
 </html>

--- a/Aurora/public/privacy.html
+++ b/Aurora/public/privacy.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Privacy Policy</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body style="padding:1rem;">
+  <h3>Privacy Policy for Alfe AI</h3>
+  <p><em>Effective Date: 05/22/25</em></p>
+  <pre style="white-space: pre-wrap;">
+Privacy Policy for Alfe AI
+
+Effective Date: 05/22/25
+
+Alfe AI ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy describes how we collect, use, and protect personal data when you access or use our services.
+
+1. Information We Collect
+
+a. Information You Provide Directly
+
+Account registration details (e.g., name, email)
+
+User content (files, text, prompts, notes)
+
+Feedback and support requests
+
+b. Automatically Collected Data
+
+Device information (model, OS, browser)
+
+Usage metrics (app interactions, performance logs)
+
+Cookies and similar tracking technologies (only where applicable and disclosed, and in accordance with relevant consent laws such as the EU's ePrivacy Directive). For more information on how we use cookies and how you can manage your preferences, please refer to our Cookie Policy or adjust your settings via the in-app consent banner.
+
+c. Optional Data Contributions
+
+Only if opted-in, anonymized content may be used to improve model accuracy and system performance.
+
+2. How We Use Your Information
+
+We use collected data to:
+
+Operate and improve our services
+
+Personalize user experiences
+
+Provide support and respond to inquiries
+
+Secure our systems and detect misuse
+
+We do not use your content to train our models unless you have explicitly opted in through in-app settings or administrative controls. You may withdraw your consent at any time by disabling this option in your account preferences or contacting us directly.
+
+3. Local Processing & Cloud Bursting
+
+a. Local-First by Design
+
+Whenever possible, all processing occurs on your device—ensuring that your data stays private and never leaves your environment.
+
+b. Cloud Bursting (Optional)
+
+When local capacity is exceeded, certain requests may be processed securely in our cloud infrastructure, confined to your selected region. All data transmissions are encrypted in transit.
+
+4. Enterprise Privacy Controls
+
+a. Zero-Log Mode
+
+Enterprise customers may enable zero-log mode, which ensures no readable logs or user data are stored—even temporarily.
+
+b. Audit & Access Controls
+
+Administrative controls allow enterprise tenants to restrict access, review usage logs, and enforce privacy policies.
+
+5. Sharing of Information
+
+We do not sell or rent personal data. We may share information only:
+
+With third-party data processors—defined as service providers who process data on our behalf—under strict confidentiality and security obligations. A current list of subprocessors is available upon request or via our Subprocessor Disclosure Page
+
+To comply with legal obligations or enforce our terms
+
+With your explicit consent
+
+6. Data Retention
+
+We retain your data only as long as necessary to provide the service or meet legal obligations. Optional data shared for research or improvements is de-identified and aggregated.
+
+7. Your Rights & Choices
+
+Depending on your jurisdiction, you may have rights under the GDPR, CCPA, or similar laws to:
+
+Access your data
+
+Correct or delete inaccuracies
+
+Restrict or object to processing
+
+Port your data elsewhere
+
+To exercise these rights, contact legal@alfe.sh.
+
+8. Security
+
+We apply technical and organizational measures such as:
+
+Encryption at rest and in transit
+
+Role-based access control
+
+Regular audits and vulnerability scans
+
+9. International Transfers
+
+If you access our services from outside the United States, your information may be transferred to and processed in the U.S. or other countries with appropriate safeguards. These transfers are based on recognized legal mechanisms, such as Standard Contractual Clauses (SCCs), to ensure your data remains protected according to applicable privacy laws. or other countries with appropriate safeguards.
+
+10. Changes to This Policy
+
+We may update this Privacy Policy from time to time. If we make material changes, we will notify users through prominent notices within the app or via email where appropriate, in accordance with applicable data protection laws. The "Effective Date" at the top will reflect the latest revision. Continued use of our services indicates acceptance of the updated policy.
+
+11. Contact Us
+
+If you have any questions or concerns about this policy, please contact us at:
+
+Lochner Technology and Commerce, LLC2501 Chatham Rd. #4328Springfield, IL 62704, USAEmail: legal@alfe.sh
+
+Thank you for trusting Alfe AI to respect your privacy.
+  </pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `privacy.html` with the full Alfe AI privacy policy
- link the new policy from `about.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68421449db2c8323add608a4a95b4c8f