### PR TITLE
Fix thin sidebar icons on mobile

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3312,6 +3312,10 @@ btnNexumTabsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSi
 thinChatIcon?.addEventListener("click", () => openPanelWithSidebar(showChatTabsPanel));
 thinImagesIcon?.addEventListener("click", () => openPanelWithSidebar(showUploaderPanel));
 thinArchiveIcon?.addEventListener("click", () => openPanelWithSidebar(showArchiveTabsPanel));
+// Ensure taps on mobile trigger the same actions
+thinChatIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showChatTabsPanel));
+thinImagesIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showUploaderPanel));
+thinArchiveIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showArchiveTabsPanel));
 
 (async function init(){
   const placeholderEl = document.getElementById("chatPlaceholder");

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -1006,8 +1006,9 @@ body {
   border: none;
   color: #ddd;
   font-size: 1.2rem;
-  margin: 4px 0;
+  margin: 8px 0; /* more spacing for easier tapping */
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 /* Version info in sidebar */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -1009,8 +1009,9 @@ body {
   border: none;
   color: #333;
   font-size: 1.2rem;
-  margin: 4px 0;
+  margin: 8px 0; /* more spacing for easier tapping */
   cursor: pointer;
+  touch-action: manipulation;
 }
 
 /* Version info in sidebar */


### PR DESCRIPTION
## Summary
- ensure thin sidebar icons respond to touch events
- increase spacing between thin sidebar icons for better usability

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6842159416408323ace27cf129855f2c