### PR TITLE
Add model info for image chat pairs

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1888,6 +1888,8 @@ function parseProviderModel(model) {
     return { provider: "openrouter", shortModel: model.replace(/^openrouter\//,'') };
   } else if(model.startsWith("deepseek/")) {
     return { provider: "openrouter", shortModel: model.replace(/^deepseek\//,'') };
+  } else if(model.startsWith("stable-diffusion/")) {
+    return { provider: "stable-diffusion", shortModel: model.replace(/^stable-diffusion\//,'') };
   }
   return { provider: "Unknown", shortModel: model };
 }
@@ -3696,7 +3698,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
           }
         }
 
-        if(!p.image_url){
+        if(p.model){
           // Show model name at bottom-left of AI bubble
           const modelDiv = document.createElement("div");
           modelDiv.className = "model-indicator";
@@ -3871,7 +3873,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
     }
   }
 
-  if(!imageUrl){
+  if(model){
     // Show model name at bottom-left of AI bubble
     const modelDiv = document.createElement("div");
     modelDiv.className = "model-indicator";

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2299,7 +2299,8 @@ app.post("/api/image/generate", async (req, res) => {
       );
       const tab = parseInt(tabId, 10) || 1;
       const imageTitle = await deriveImageTitle(prompt);
-      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress);
+      const modelId = model ? `stable-diffusion/${model}` : 'stable-diffusion';
+      db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
       return res.json({ success: true, url: localUrl, title: imageTitle });
     }
 
@@ -2383,7 +2384,8 @@ app.post("/api/image/generate", async (req, res) => {
 
     const tab = parseInt(tabId, 10) || 1;
     const imageTitle = await deriveImageTitle(prompt, openaiClient);
-    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress);
+    const modelId = `openai/${modelName}`;
+    db.createImagePair(localUrl, prompt || '', tab, imageTitle, 'Generated', sessionId, ipAddress, modelId);
 
     res.json({ success: true, url: localUrl, title: imageTitle });
   } catch (err) {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -653,7 +653,7 @@ export default class TaskDB {
     });
   }
 
-  createImagePair(url, altText = '', chatTabId = 1, title = '', status = 'Generated', sessionId = '', ipAddress = '') {
+  createImagePair(url, altText = '', chatTabId = 1, title = '', status = 'Generated', sessionId = '', ipAddress = '', model = '') {
     const ts = new Date().toISOString();
     const uuid = randomUUID().split('-')[0];
     const { lastInsertRowid } = this.db.prepare(`
@@ -661,8 +661,8 @@ export default class TaskDB {
         user_text, ai_text, model, timestamp, ai_timestamp,
         chat_tab_id, system_context, token_info,
         image_url, image_alt, image_title, image_status, session_id, ip_address, image_uuid
-      ) VALUES ('', '', '', @ts, @ts, @chat_tab_id, '', NULL, @url, @alt, @title, @status, @session_id, @ip_address, @uuid)
-    `).run({ ts, chat_tab_id: chatTabId, url, alt: altText, title, status, session_id: sessionId, ip_address: ipAddress, uuid });
+      ) VALUES ('', '', @model, @ts, @ts, @chat_tab_id, '', NULL, @url, @alt, @title, @status, @session_id, @ip_address, @uuid)
+    `).run({ ts, chat_tab_id: chatTabId, url, alt: altText, title, status, session_id: sessionId, ip_address: ipAddress, uuid, model });
     return lastInsertRowid;
   }
 
@@ -980,7 +980,7 @@ export default class TaskDB {
     const stmt = this.db.prepare("UPDATE chat_pairs SET image_status=? WHERE image_url=?");
     const info = stmt.run(status, url);
     if(info.changes === 0){
-      this.createImagePair(url, '', 1, '', status, '', '');
+      this.createImagePair(url, '', 1, '', status, '', '', '');
     }
   }
 


### PR DESCRIPTION
## Summary
- store the image generation model when creating image chat pairs
- display the model name for all chat pairs, including images
- handle `stable-diffusion` prefix in model parsing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684215ed0510832395a4725401fba82a