### PR TITLE
Fix duplicate image generation

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -102,6 +102,7 @@ let imageLoopEnabled = false; // automatic image generation loop mode
 let imageLoopMessage = "Next image";
 let imageGenService = 'openai';
 let isImageGenerating = false; // true while an image is being generated
+let lastImagePrompt = null; // avoid repeating generation for same prompt
 let imageUploadEnabled = false; // show image upload button
 let imagePaintTrayEnabled = true; // show image paint tray button
 let activityIframeMenuVisible = false; // show Activity IFrame menu item
@@ -4614,9 +4615,12 @@ registerActionHook("afterSendLog", ({message, response}) => {
 // Automatically generate an image from the AI response
 registerActionHook("generateImage", async ({response}) => {
   try {
+    if(isImageGenerating) return;
     if(currentTabType !== 'design' || !tabGenerateImages) return;
     const prompt = (response || "").trim();
     if(!prompt) return;
+    if(prompt === lastImagePrompt) return;
+    lastImagePrompt = prompt;
     isImageGenerating = true;
     if(chatInputEl) chatInputEl.disabled = true;
     if(chatSendBtnEl) chatSendBtnEl.disabled = true;
@@ -4635,6 +4639,7 @@ registerActionHook("generateImage", async ({response}) => {
       scrollChatToBottom();
     }
     isImageGenerating = false;
+    lastImagePrompt = null;
     if(chatInputEl) chatInputEl.disabled = false;
     if(chatSendBtnEl) chatSendBtnEl.disabled = false;
     const data = await r.json();
@@ -4657,6 +4662,7 @@ registerActionHook("generateImage", async ({response}) => {
       scrollChatToBottom();
     }
     isImageGenerating = false;
+    lastImagePrompt = null;
     if(chatInputEl) chatInputEl.disabled = false;
     if(chatSendBtnEl) chatSendBtnEl.disabled = false;
     console.error('[Hook generateImage] failed:', err);


### PR DESCRIPTION
## Summary
- prevent concurrent image generation in Aurora's UI
- skip repeated prompts to avoid duplicate images

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68421717e51c832385d2a8aab71062bc