### PR TITLE
Fix sidebar touch events on mobile

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3312,13 +3312,37 @@ btnPipelineQueueIcon?.addEventListener("click", () => { if(!sidebarVisible) togg
 btnNexumChatIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumChat.dataset.url; });
 btnNexumTabsIcon?.addEventListener("click", () => { if(!sidebarVisible) toggleSidebar(); window.location.href = btnNexumTabs.dataset.url; });
 // Thin sidebar icon actions
-thinChatIcon?.addEventListener("click", () => openPanelWithSidebar(showChatTabsPanel));
-thinImagesIcon?.addEventListener("click", () => openPanelWithSidebar(showUploaderPanel));
-thinArchiveIcon?.addEventListener("click", () => openPanelWithSidebar(showArchiveTabsPanel));
+thinChatIcon?.addEventListener("click", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showChatTabsPanel);
+});
+thinImagesIcon?.addEventListener("click", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showUploaderPanel);
+});
+thinArchiveIcon?.addEventListener("click", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showArchiveTabsPanel);
+});
 // Ensure taps on mobile trigger the same actions
-thinChatIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showChatTabsPanel));
-thinImagesIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showUploaderPanel));
-thinArchiveIcon?.addEventListener("touchstart", () => openPanelWithSidebar(showArchiveTabsPanel));
+thinChatIcon?.addEventListener("touchstart", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showChatTabsPanel);
+});
+thinImagesIcon?.addEventListener("touchstart", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showUploaderPanel);
+});
+thinArchiveIcon?.addEventListener("touchstart", ev => {
+  ev.preventDefault();
+  ev.stopPropagation();
+  openPanelWithSidebar(showArchiveTabsPanel);
+});
 
 (async function init(){
   const placeholderEl = document.getElementById("chatPlaceholder");


### PR DESCRIPTION
## Summary
- stop event propagation when tapping thin sidebar icons

## Testing
- `npm test` in `Aurora` *(fails: Missing script)*
- `npm test` in `Sterling` *(fails: Missing script)*
- `npm run lint` in `Aurora`


------
https://chatgpt.com/codex/tasks/task_b_68421d5ed9448323b8cd5ab0c48b305d