### PR TITLE
Fix duplicate image generation in design chats

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4643,6 +4643,9 @@ registerActionHook("generateImage", async ({response}) => {
     const prompt = (response || "").trim();
     if(!prompt) return;
     if(prompt === lastImagePrompt) return;
+    // If the response already contains placeholder image links,
+    // let the embedMockImages hook handle them to avoid duplicates
+    if(/!\[[^\]]*\]\(https:\/\/alfe\.sh\/[^)]+\)/.test(prompt)) return;
     lastImagePrompt = prompt;
     isImageGenerating = true;
     if(chatSendBtnEl) chatSendBtnEl.disabled = true;


### PR DESCRIPTION
## Summary
- prevent `generateImage` hook from creating images when placeholder links already exist

## Testing
- `npm test` *(fails: could not read package.json)*
- `(cd Sterling && npm test)` *(fails: missing `test` script)*

------
https://chatgpt.com/codex/tasks/task_b_68422870846883239479c81e79dc7f16