### PR TITLE
Improve debug logs and handle missing GitHub config

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4638,14 +4638,30 @@ registerActionHook("afterSendLog", ({message, response}) => {
 // Automatically generate an image from the AI response
 registerActionHook("generateImage", async ({response}) => {
   try {
-    if(isImageGenerating) return;
-    if(currentTabType !== 'design' || !tabGenerateImages) return;
+    console.debug('[Hook generateImage] invoked with:', response);
+    if(isImageGenerating){
+      console.debug('[Hook generateImage] skipping - already generating');
+      return;
+    }
+    if(currentTabType !== 'design' || !tabGenerateImages){
+      console.debug('[Hook generateImage] skipping - not design tab or disabled');
+      return;
+    }
     const prompt = (response || "").trim();
-    if(!prompt) return;
-    if(prompt === lastImagePrompt) return;
+    if(!prompt){
+      console.debug('[Hook generateImage] skipping - empty prompt');
+      return;
+    }
+    if(prompt === lastImagePrompt){
+      console.debug('[Hook generateImage] skipping - duplicate prompt');
+      return;
+    }
     // If the response already contains placeholder image links,
     // let the embedMockImages hook handle them to avoid duplicates
-    if(/!\[[^\]]*\]\(https:\/\/alfe\.sh\/[^)]+\)/.test(prompt)) return;
+    if(/!\[[^\]]*\]\(https:\/\/alfe\.sh\/[^)]+\)/.test(prompt)){
+      console.debug('[Hook generateImage] skipping - contains placeholder');
+      return;
+    }
     lastImagePrompt = prompt;
     isImageGenerating = true;
     if(chatSendBtnEl) chatSendBtnEl.disabled = true;
@@ -4654,11 +4670,13 @@ registerActionHook("generateImage", async ({response}) => {
       genIndicator.style.display = "";
       scrollChatToBottom();
     }
+    console.debug('[Hook generateImage] sending request to /api/image/generate');
     const r = await fetch('/api/image/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt, tabId: currentTabId, provider: imageGenService, sessionId })
     });
+    console.debug('[Hook generateImage] response status', r.status);
     if(genIndicator) {
       genIndicator.style.display = "none";
       scrollChatToBottom();

--- a/Aurora/src/githubClient.js
+++ b/Aurora/src/githubClient.js
@@ -5,13 +5,16 @@ import { Octokit } from "@octokit/rest";
  */
 export default class GitHubClient {
   constructor({ token, owner, repo }) {
+    this.owner = owner;
+    this.repo = repo;
     if (!token || !owner || !repo) {
-      //throw new Error("GitHub token, owner and repo must be provided");
+      console.warn(
+        "[GitHubClient] Missing token/owner/repo. GitHub integration disabled."
+      );
+      this.octokit = null;
       return;
     }
 
-    this.owner = owner;
-    this.repo = repo;
     this.octokit = new Octokit({ auth: token });
   }
 
@@ -48,11 +51,14 @@ export default class GitHubClient {
    * @returns {Promise<Object>} newly created issue object
    */
   async createIssue(title, body = "") {
+    if (!this.octokit) {
+      throw new Error("GitHub client not configured");
+    }
     const { data } = await this.octokit.issues.create({
       owner: this.owner,
       repo: this.repo,
       title,
-      body
+      body,
     });
     return data;
   }
@@ -64,11 +70,14 @@ export default class GitHubClient {
    * @param {string} newTitle
    */
   async updateIssueTitle(issueNumber, newTitle) {
+    if (!this.octokit) {
+      throw new Error("GitHub client not configured");
+    }
     const { data } = await this.octokit.issues.update({
       owner: this.owner,
       repo: this.repo,
       issue_number: issueNumber,
-      title: newTitle
+      title: newTitle,
     });
     return data;
   }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -717,6 +717,15 @@ app.post("/api/tasks/new", async (req, res) => {
       repo: process.env.GITHUB_REPO
     });
 
+    if (!gh.octokit) {
+      console.debug(
+        "[Server Debug] GitHub credentials missing; skipping issue creation."
+      );
+      return res
+        .status(200)
+        .json({ success: false, message: "GitHub not configured" });
+    }
+
     const newIssue = await gh.createIssue(title, body || "");
     db.upsertIssue(newIssue, `${gh.owner}/${gh.repo}`);
     db.logActivity(


### PR DESCRIPTION
## Summary
- warn when GitHub credentials aren't set and disable GitHubClient
- gracefully skip issue creation when GitHub isn't configured
- add detailed debug output for automatic image generation hook

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68422993ce7883239aac7ab6795c883a