### PR TITLE
Add AI Favorites modal

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -167,6 +167,7 @@
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>
+      <button id="aiFavoritesBtn" class="top-btn" title="AI Favorites">⚙️</button>
       <button id="signupBtn" class="top-btn">Sign Up/Login</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
@@ -485,6 +486,16 @@
     <div class="modal-buttons">
       <button id="globalAiSettingsSaveBtn">Save</button>
       <button id="globalAiSettingsCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<div id="aiFavoritesModal" class="modal">
+  <div class="modal-content">
+    <h2>AI Favorites</h2>
+    <div id="aiFavoritesList"></div>
+    <div class="modal-buttons">
+      <button id="aiFavoritesCloseBtn">Close</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4419,6 +4419,65 @@ document.getElementById("globalAiSettingsCancelBtn").addEventListener("click", (
 });
 
 // ----------------------------------------------------------------------
+// AI Favorites modal
+// ----------------------------------------------------------------------
+async function openAiFavoritesModal(){
+  const listEl = document.getElementById("aiFavoritesList");
+  if(listEl){
+    listEl.textContent = "Loading...";
+    try{
+      const resp = await fetch("/api/ai/models");
+      if(resp.ok){
+        const data = await resp.json();
+        const models = data.models || [];
+        listEl.innerHTML = "";
+        models.forEach(m => {
+          const row = document.createElement("div");
+          const star = document.createElement("span");
+          star.dataset.modelid = m.id;
+          star.className = m.favorite ? "favorite-star starred" : "favorite-star unstarred";
+          star.textContent = m.favorite ? "★" : "☆";
+          star.addEventListener("click", async () => {
+            const newFav = !star.classList.contains("starred");
+            try {
+              const r = await fetch("/api/ai/favorites", {
+                method: "POST",
+                headers: {"Content-Type":"application/json"},
+                body: JSON.stringify({modelId: m.id, favorite: newFav})
+              });
+              if(r.ok){
+                star.classList.toggle("starred", newFav);
+                star.classList.toggle("unstarred", !newFav);
+                star.textContent = newFav ? "★" : "☆";
+                m.favorite = newFav;
+              }
+            }catch(e){
+              console.error("Error toggling favorite:", e);
+            }
+          });
+          row.appendChild(star);
+          const label = document.createElement("span");
+          label.textContent = " " + m.id;
+          row.appendChild(label);
+          listEl.appendChild(row);
+        });
+      }else{
+        listEl.textContent = "Error";
+      }
+    }catch(e){
+      console.error("Error loading models:", e);
+      listEl.textContent = "Error";
+    }
+  }
+  showModal(document.getElementById("aiFavoritesModal"));
+}
+
+document.getElementById("aiFavoritesBtn").addEventListener("click", openAiFavoritesModal);
+document.getElementById("aiFavoritesCloseBtn").addEventListener("click", () => {
+  hideModal(document.getElementById("aiFavoritesModal"));
+});
+
+// ----------------------------------------------------------------------
 // Feature Flags modal
 // ----------------------------------------------------------------------
 async function loadFeatureFlags(){

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -784,6 +784,15 @@ body {
   margin-left: 4px;
 }
 
+/* Star icon style used in AI Favorites modal */
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.starred { color: gold; }
+.unstarred { color: #777; }
+
 /* Basic style for chat subroutine cards */
 .subroutine-card {
   background: #333;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -787,6 +787,15 @@ body {
   margin-left: 4px;
 }
 
+/* Star icon style used in AI Favorites modal */
+.favorite-star {
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
+}
+.starred { color: gold; }
+.unstarred { color: #555; }
+
 /* Basic style for chat subroutine cards */
 .subroutine-card {
   background: #ccc;


### PR DESCRIPTION
## Summary
- add AI Favorites gear button in Aurora top bar
- implement AI Favorites modal to toggle favorite models
- style star icons in both dark and light themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684233ccacdc8323894e999d6a43b0f2