### PR TITLE
Limit width of images in Aurora chat

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -366,10 +366,10 @@ body {
   font-family: monospace;      /* Changed to monospaced */
 }
 
-/* Ensure images fit within chat bubbles */
+/* Ensure images fit within chat bubbles and cap width */
 .chat-user img,
 .chat-bot img {
-  max-width: 100%;
+  max-width: min(100%, 400px);
   height: auto;
 }
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -369,10 +369,10 @@ body {
   font-family: monospace;      /* Changed to monospaced */
 }
 
-/* Ensure images fit within chat bubbles */
+/* Ensure images fit within chat bubbles and cap width */
 .chat-user img,
 .chat-bot img {
-  max-width: 100%;
+  max-width: min(100%, 400px);
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- cap chat image width to 400px while keeping bubble constraints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68422851533c83239abde3348237ecb4