### PR TITLE
Limit image widths to 400px

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -145,9 +145,9 @@
     const origImg = document.createElement('img');
     const upscaledImg = document.createElement('img');
     const nobgImg = document.createElement('img');
-    origImg.style.maxWidth = '600px';
-    upscaledImg.style.maxWidth = '600px';
-    nobgImg.style.maxWidth = '600px';
+    origImg.style.maxWidth = '400px';
+    upscaledImg.style.maxWidth = '400px';
+    nobgImg.style.maxWidth = '400px';
     upscaledImg.style.display = 'none';
     nobgImg.style.display = 'none';
     container.appendChild(origImg);

--- a/Aurora/public/generated_images.html
+++ b/Aurora/public/generated_images.html
@@ -17,7 +17,7 @@
       gap:10px;
     }
     .grid img {
-      max-width:600px;
+      max-width:400px;
       width:100%;
       border:1px solid #444;
     }

--- a/Aurora/public/image_generator.html
+++ b/Aurora/public/image_generator.html
@@ -25,7 +25,7 @@
       margin-top:1rem;
     }
     img {
-      max-width:600px;
+      max-width:400px;
       width:100%;
       border:1px solid #444;
     }

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -3722,7 +3722,7 @@ async function loadChatHistory(tabId = 1, reset=false) {
           img.src = p.image_url;
           img.alt = p.image_alt || "";
           if(p.image_title) img.title = p.image_title;
-          img.style.maxWidth = "100%";
+          img.style.maxWidth = "min(100%, 400px)";
           img.style.height = "auto";
           botDiv.appendChild(img);
         }
@@ -3898,7 +3898,7 @@ function addChatMessage(pairId, userText, userTs, aiText, aiTs, model, systemCon
     img.src = imageUrl;
     img.alt = imageAlt;
     if(imageTitle) img.title = imageTitle;
-    img.style.maxWidth = "100%";
+    img.style.maxWidth = "min(100%, 400px)";
     img.style.height = "auto";
     botDiv.appendChild(img);
   }
@@ -4640,7 +4640,7 @@ function addImageChatBubble(url, altText="", title=""){
   img.src = url;
   img.alt = altText;
   if(title) img.title = title;
-  img.style.maxWidth = "100%";
+  img.style.maxWidth = "min(100%, 400px)";
   img.style.height = "auto";
   img.addEventListener('load', scrollChatToBottom);
   botDiv.appendChild(img);


### PR DESCRIPTION
## Summary
- ensure chat images never exceed 400px in width
- limit generated image previews to 400px
- keep image generator results within 400px
- cap image detail view images at 400px

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684236664af88323b4d42c3343d621e9