### PR TITLE
Fix chat subbubble buttons placement

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -273,7 +273,7 @@ body {
 
 .bubble-delete-btn {
   position: absolute;
-  top: -16px;
+  top: 4px; /* align inside bubble */
   right: 4px;
 }
 
@@ -286,8 +286,8 @@ body {
 
 .bubble-copy-btn {
   position: absolute;
-  top: -16px;
-  right: 36px; /* increased for better spacing from delete button */
+  top: 4px; /* align inside bubble */
+  right: 36px; /* space from delete button */
   background: transparent;
   border: none;
   color: #4da3ff;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -276,7 +276,7 @@ body {
 
 .bubble-delete-btn {
   position: absolute;
-  top: -16px;
+  top: 4px; /* align inside bubble */
   right: 4px;
 }
 
@@ -289,8 +289,8 @@ body {
 
 .bubble-copy-btn {
   position: absolute;
-  top: -16px;
-  right: 36px; /* increased for better spacing from delete button */
+  top: 4px; /* align inside bubble */
+  right: 36px; /* space from delete button */
   background: transparent;
   border: none;
   color: #4da3ff;


### PR DESCRIPTION
## Summary
- adjust copy/delete button offsets in subbubbles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6842466807ec8323912f661059a61af7