### PR TITLE
Fix alignment of chat subbubble buttons

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -323,6 +323,7 @@ body {
   gap: 8px; /* increased for better spacing */
   margin-bottom: 6px; /* increased for a bit more breathing room */
   font-size: 0.9rem;
+  position: relative;
 }
 
 /* Date header separating chat days */
@@ -378,7 +379,6 @@ body {
 .chat-bot {
   font-size: 0.95rem;
   position: relative;
-  top: 10px;
 }
 
 /* Thumbnail for user uploaded images */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -326,6 +326,7 @@ body {
   gap: 8px; /* increased for better spacing */
   margin-bottom: 6px; /* increased for a bit more breathing room */
   font-size: 0.9rem;
+  position: relative;
 }
 
 /* Date header separating chat days */
@@ -381,7 +382,6 @@ body {
 .chat-bot {
   font-size: 0.95rem;
   position: relative;
-  top: 10px;
 }
 
 /* Thumbnail for user uploaded images */


### PR DESCRIPTION
## Summary
- ensure bubble header is a positioned container so copy/delete buttons align
- remove stray vertical offset from chat bubbles in both themes

## Testing
- `npm run -s lint --prefix Aurora`
- `npm run -s test --prefix AutoPR`
- `npm run -s test --prefix VMRunner`

------
https://chatgpt.com/codex/tasks/task_b_684247ebda008323b1bc9928ca0350df