### PR TITLE
Fix vertical alignment of chat action buttons

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -275,6 +275,8 @@ body {
   position: absolute;
   top: 4px; /* align inside bubble */
   right: 4px;
+  line-height: 1; /* consistent vertical alignment */
+  font-size: 1rem;
 }
 
 .model-delete-btn {
@@ -292,6 +294,8 @@ body {
   border: none;
   color: #4da3ff;
   font-weight: bold;
+  font-size: 1rem;
+  line-height: 1; /* ensure same baseline as trash button */
   cursor: pointer;
 }
 

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -278,6 +278,8 @@ body {
   position: absolute;
   top: 4px; /* align inside bubble */
   right: 4px;
+  line-height: 1; /* consistent vertical alignment */
+  font-size: 1rem;
 }
 
 .model-delete-btn {
@@ -295,6 +297,8 @@ body {
   border: none;
   color: #4da3ff;
   font-weight: bold;
+  font-size: 1rem;
+  line-height: 1; /* ensure same baseline as trash button */
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- ensure the delete and copy action buttons share the same baseline for chat bubbles

## Testing
- `npm run lint` *(Aurora)*
- `npm test` *(Aurora, Sterling, AuroraMobile, AutoPR – no tests defined)*

------
https://chatgpt.com/codex/tasks/task_b_684249b98f4c832394698a193585b62b