### PR TITLE
Fix placeholder image filtering

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -195,7 +195,8 @@ function stripPlaceholderImageLines(text){
   if(!text) return text;
   return text
     .split("\n")
-    .filter(line => !/!\[[^\]]*\]\(https:\/\/alfe\.sh\/abstract-calm-\d+\.png\)/.test(line.trim()))
+    // Strip any Alfe placeholder images (abstract calm, puzzle borders, etc.)
+    .filter(line => !/!\[[^\]]*\]\(https?:\/\/alfe\.sh\/[^)]+\)/.test(line.trim()))
     .join("\n");
 }
 


### PR DESCRIPTION
## Summary
- expand regex to remove any alfe.sh placeholder image links from AI text

## Testing
- `npm test` in AutoPR
- `npm test` in Aurora (fails: Missing script)
- `npm test` in AuroraMobile (fails: Missing script)
- `npm test` in Sterling (fails: Missing script)
- `npm test` in VMRunner (fails: no test specified)
- `npm test` in stirfry/stirfry (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_b_6842478f875483238294df280906f1d7