### PR TITLE
Remove brand name from Aurora version display

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -19,7 +19,7 @@
   <aside class="sidebar">
     <img id="sidebarToggleIcon" class="sidebar-toggle-icon" src="/alfe_favicon_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <span id="closeSidebarIcon" class="close-sidebar-icon">&laquo;</span>
-    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;">Alfe AI <span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a></div>
+    <div id="versionInfo" class="version-info" style="margin-bottom: 5px;"><span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a></div>
     <span id="sessionIdText" class="session-id"></span>
     <button id="hideSidebarBtn" class="hide-sidebar-btn">Hide Sidebar</button>
     <span id="imageLimitInfo" class="session-limit"></span>


### PR DESCRIPTION
## Summary
- simplify version info sidebar to only show the version

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68424d77ae988323aa7e284314143711