### PR TITLE
Add brand text to Aurora sidebar

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -17,6 +17,7 @@
 
 <div class="app">
   <aside class="sidebar">
+    <span id="sidebarBrandText" class="sidebar-brand-text">Alfe AI</span>
     <img id="sidebarToggleIcon" class="sidebar-toggle-icon" src="/alfe_favicon_64x64.ico" alt="Toggle sidebar" title="Toggle sidebar"/>
     <span id="closeSidebarIcon" class="close-sidebar-icon">&laquo;</span>
     <div id="versionInfo" class="version-info" style="margin-bottom: 5px;">Alfe AI <span id="versionSpan">beta-...</span> <a href="/about.html" target="_blank" style="color: cyan">about</a></div>

--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -594,11 +594,25 @@ body {
 .sidebar-toggle-icon {
   position: absolute;
   top: 8px;
-  left: 8px;
+  left: 100px;
   width: 42px;
   height: 42px;
   cursor: pointer;
   z-index: 1000;
+}
+
+.sidebar-brand-text {
+  position: absolute;
+  top: 16px;
+  left: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+  z-index: 1000;
+}
+
+.app.sidebar-collapsed #sidebarBrandText {
+  display: none;
 }
 
 .close-sidebar-icon {
@@ -626,7 +640,7 @@ body {
   display: none;
   position: absolute;
   top: 16px;
-  left: 60px;
+  left: 152px;
   font-size: 0.8rem;
   color: #aaa;
   z-index: 1000;
@@ -637,7 +651,7 @@ body {
 #imageLimitInfo.session-limit {
   position: absolute;
   top: 32px;
-  left: 60px;
+  left: 152px;
   font-size: 0.75rem;
   color: #aaa;
   z-index: 1000;
@@ -646,7 +660,7 @@ body {
 #imageLimitCountdown.session-limit {
   position: absolute;
   top: 44px;
-  left: 60px;
+  left: 152px;
   font-size: 0.7rem;
   color: #aaa;
   z-index: 1000;

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -597,11 +597,25 @@ body {
 .sidebar-toggle-icon {
   position: absolute;
   top: 8px;
-  left: 8px;
+  left: 100px;
   width: 42px;
   height: 42px;
   cursor: pointer;
   z-index: 1000;
+}
+
+.sidebar-brand-text {
+  position: absolute;
+  top: 16px;
+  left: 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  color: #000;
+  z-index: 1000;
+}
+
+.app.sidebar-collapsed #sidebarBrandText {
+  display: none;
 }
 
 .close-sidebar-icon {
@@ -629,7 +643,7 @@ body {
   display: none;
   position: absolute;
   top: 16px;
-  left: 60px;
+  left: 152px;
   font-size: 0.8rem;
   color: #aaa;
   z-index: 1000;
@@ -640,7 +654,7 @@ body {
 #imageLimitInfo.session-limit {
   position: absolute;
   top: 32px;
-  left: 60px;
+  left: 152px;
   font-size: 0.75rem;
   color: #aaa;
   z-index: 1000;
@@ -649,7 +663,7 @@ body {
 #imageLimitCountdown.session-limit {
   position: absolute;
   top: 44px;
-  left: 60px;
+  left: 152px;
   font-size: 0.7rem;
   color: #aaa;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- add "Alfe AI" text element in aurora sidebar
- style sidebar brand text for dark and light themes
- shift sidebar logo and counters to accommodate brand text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68424d67d5a08323b41dd2736f0947e1