### PR TITLE
Add timezone setting

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -685,6 +685,12 @@
       </div>
       <p id="totpEnabledMsg" style="display:none;">2FA Enabled</p>
     </div>
+    <div id="timezoneSection" style="margin-top:10px;">
+      <label>Timezone:<br/>
+        <input type="text" id="accountTimezone" style="width:100%;" placeholder="e.g., America/Chicago" />
+      </label>
+      <button id="timezoneSaveBtn" style="margin-top:8px;">Save</button>
+    </div>
     <div class="modal-buttons">
       <button id="accountLogoutBtn">Logout</button>
       <button id="accountCloseBtn">Close</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -229,6 +229,8 @@ function openAccountModal(e){
   if(accountInfo){
     const emailEl = document.getElementById("accountEmail");
     if(emailEl) emailEl.textContent = accountInfo.email;
+    const tzEl = document.getElementById('accountTimezone');
+    if(tzEl) tzEl.value = accountInfo.timezone || '';
     const enabledMsg = document.getElementById('totpEnabledMsg');
     const enableBtn = document.getElementById('enableTotpBtn');
     if(accountInfo.totpEnabled){
@@ -1780,6 +1782,25 @@ if(totpVerifyBtn){
       showToast('2FA enabled');
     } else {
       showToast(data?.error || 'Verification failed');
+    }
+  });
+}
+
+const timezoneSaveBtn = document.getElementById('timezoneSaveBtn');
+if(timezoneSaveBtn){
+  timezoneSaveBtn.addEventListener('click', async () => {
+    const tz = document.getElementById('accountTimezone').value.trim();
+    const resp = await fetch('/api/account/timezone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ timezone: tz })
+    });
+    const data = await resp.json().catch(() => null);
+    if(resp.ok && data && data.success){
+      if(accountInfo) accountInfo.timezone = tz;
+      showToast('Timezone saved');
+    } else {
+      showToast(data?.error || 'Failed to save timezone');
     }
   });
 }

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -904,11 +904,29 @@ app.get("/api/account", (req, res) => {
     const sessionId = getSessionIdFromRequest(req);
     const account = sessionId ? db.getAccountBySession(sessionId) : null;
     if (!account) return res.json({ exists: false });
-    res.json({ exists: true, id: account.id, email: account.email, totpEnabled: !!account.totp_secret });
+    res.json({
+      exists: true,
+      id: account.id,
+      email: account.email,
+      totpEnabled: !!account.totp_secret,
+      timezone: account.timezone || ''
+    });
   } catch(err) {
     console.error("[TaskQueue] GET /api/account failed:", err);
     res.status(500).json({ error: "Internal server error" });
   }
+});
+
+app.post("/api/account/timezone", (req, res) => {
+  const sessionId = getSessionIdFromRequest(req);
+  const account = sessionId ? db.getAccountBySession(sessionId) : null;
+  if (!account) return res.status(401).json({ error: "not logged in" });
+  const { timezone } = req.body || {};
+  if (typeof timezone !== 'string') {
+    return res.status(400).json({ error: "timezone required" });
+  }
+  db.setAccountTimezone(account.id, timezone);
+  res.json({ success: true });
 });
 
 app.post("/api/logout", (req, res) => {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -283,13 +283,21 @@ export default class TaskDB {
         password_hash TEXT NOT NULL,
         session_id TEXT DEFAULT '',
         created_at TEXT NOT NULL,
-        totp_secret TEXT DEFAULT ''
+        totp_secret TEXT DEFAULT '',
+        timezone TEXT DEFAULT ''
       );
     `);
 
     try {
       this.db.exec('ALTER TABLE accounts ADD COLUMN totp_secret TEXT DEFAULT "";');
       console.debug("[TaskDB Debug] Added accounts.totp_secret column");
+    } catch(e) {
+      // column exists
+    }
+
+    try {
+      this.db.exec('ALTER TABLE accounts ADD COLUMN timezone TEXT DEFAULT "";');
+      console.debug("[TaskDB Debug] Added accounts.timezone column");
     } catch(e) {
       // column exists
     }
@@ -1007,14 +1015,14 @@ export default class TaskDB {
     return row ? row.upscaled : null;
   }
 
-  createAccount(email, passwordHash, sessionId = '') {
+  createAccount(email, passwordHash, sessionId = '', timezone = '') {
     const ts = new Date().toISOString();
     const { lastInsertRowid } = this.db
         .prepare(
-            `INSERT INTO accounts (email, password_hash, session_id, created_at)
-             VALUES (?, ?, ?, ?)`
+            `INSERT INTO accounts (email, password_hash, session_id, created_at, timezone)
+             VALUES (?, ?, ?, ?, ?)`
         )
-        .run(email, passwordHash, sessionId, ts);
+        .run(email, passwordHash, sessionId, ts, timezone);
     return lastInsertRowid;
   }
 
@@ -1028,6 +1036,10 @@ export default class TaskDB {
 
   setAccountTotpSecret(id, secret) {
     this.db.prepare('UPDATE accounts SET totp_secret=? WHERE id=?').run(secret, id);
+  }
+
+  setAccountTimezone(id, timezone) {
+    this.db.prepare('UPDATE accounts SET timezone=? WHERE id=?').run(timezone, id);
   }
 
   getAccountBySession(sessionId) {


### PR DESCRIPTION
## Summary
- allow editing timezone in Aurora account modal
- store timezone in the accounts table
- expose timezone through account API

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684229fc80d88323a94f2e92df5a2829