### PR TITLE
Update fallback title heuristics

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -300,6 +300,7 @@ async function deriveImageTitle(prompt, client = null) {
   let str = prompt.trim().split('\n')[0];
   str = str.replace(/^\s*[-*]+\s*/, '');
   str = str.replace(/^(?:Thought\s+Process|Observation|Prompt|Image\s+Desc|Description|Title|Caption)\s*:\s*/i, '');
+  str = str.replace(/^here['’]s another design[:\s-]*/i, '');
   const sentEnd = str.search(/[.!?]/);
   if (sentEnd !== -1) {
     str = str.slice(0, sentEnd);
@@ -349,6 +350,7 @@ async function deriveTabTitle(message, client = null) {
   }
 
   let str = message.trim();
+  str = str.replace(/^here['’]s another design[:\s-]*/i, '');
   const sentEnd = str.search(/[.!?]/);
   if (sentEnd !== -1) {
     str = str.slice(0, sentEnd);


### PR DESCRIPTION
## Summary
- strip `Here's another design` from fallback image titles
- use same phrase stripping when deriving chat tab titles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6842527afb288323a3993d131122333e