### PR TITLE
Fix mobile subbubble overflow

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -395,7 +395,7 @@ body {
 
 /* Individual user message within a chat bubble */
 .user-subbubble {
-  min-width: 250px;
+  width: 100%;
 }
 
 /* Thumbnail images in the secure uploader table */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -398,7 +398,7 @@ body {
 
 /* Individual user message within a chat bubble */
 .user-subbubble {
-  min-width: 250px;
+  width: 100%;
 }
 
 /* Thumbnail images in the secure uploader table */


### PR DESCRIPTION
## Summary
- ensure user subbubbles take up full width of container

## Testing
- `npm run lint` in Aurora (no linter configured)
- `npm test` in AutoPR (no tests specified)
- `npm test` in AuroraMobile (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_b_6842534ea5e08323b4250370858a9787