### PR TITLE
Disable image loop mode

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -404,7 +404,7 @@
     <br/>
     <label><input type="checkbox" id="tabGenerateImagesCheck" checked /> Generate images for replies</label>
     <br/>
-    <label><input type="checkbox" id="imageLoopCheck" hidden/> Image loop mode</label>
+    <label><input type="checkbox" id="imageLoopCheck" hidden disabled/> Image loop mode</label>
     <br/>
     <label>Loop message:
       <input type="text" id="imageLoopMessageInput" style="width:100%;" />

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -2414,8 +2414,12 @@ async function openChatSettings(){
   $("#showArchivedTabsCheck").checked = showArchivedTabs;
   $("#tabGenerateImagesCheck").checked = tabGenerateImages;
   $("#tabGenerateImagesCheck").disabled = currentTabType !== 'design';
-  $("#imageLoopCheck").checked = imageLoopEnabled;
+  // Disable image loop controls
+  imageLoopEnabled = false;
+  $("#imageLoopCheck").checked = false;
+  $("#imageLoopCheck").disabled = true;
   $("#imageLoopMessageInput").value = imageLoopMessage;
+  $("#imageLoopMessageInput").disabled = true;
 
   try {
     const modelListResp = await fetch("/api/ai/models");
@@ -2567,7 +2571,10 @@ async function chatSettingsSaveFlow() {
   topChatTabsBarVisible = $("#showTopChatTabsCheck").checked;
   viewTabsBarVisible = $("#showViewTabsBarCheck").checked;
   showArchivedTabs = $("#showArchivedTabsCheck").checked;
-  imageLoopEnabled = $("#imageLoopCheck").checked;
+  // Force image loop mode off
+  imageLoopEnabled = false;
+  $("#imageLoopCheck").checked = false;
+  $("#imageLoopMessageInput").disabled = true;
   imageLoopMessage = $("#imageLoopMessageInput").value.trim() || imageLoopMessage;
 
   imageGenService = $("#imageServiceSelect").value;


### PR DESCRIPTION
## Summary
- disable image loop mode controls in Aurora UI
- ignore user input so loop mode is always off

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684259ba1dfc832384373f3619b1930b