### PR TITLE
Fix user subbubble text visibility

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -395,7 +395,7 @@ body {
 
 /* Individual user message within a chat bubble */
 .user-subbubble {
-  min-width: 350px;
+  max-width: 100%;
 }
 
 /* Thumbnail images in the secure uploader table */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -398,7 +398,7 @@ body {
 
 /* Individual user message within a chat bubble */
 .user-subbubble {
-  min-width: 350px;
+  max-width: 100%;
 }
 
 /* Thumbnail images in the secure uploader table */


### PR DESCRIPTION
## Summary
- prevent oversized subbubbles on small screens by capping width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68425ccaa8fc83239e36f7ff67b6a965