### PR TITLE
Adjust user bubble layout

### DIFF
--- a/Aurora/public/styles.css
+++ b/Aurora/public/styles.css
@@ -330,6 +330,11 @@ body {
   position: relative;
 }
 
+/* Extra space to place buttons above timestamp */
+.chat-user .bubble-header {
+  padding-top: 16px;
+}
+
 /* Date header separating chat days */
 .chat-date-header {
   text-align: center;
@@ -396,6 +401,7 @@ body {
 /* Individual user message within a chat bubble */
 .user-subbubble {
   max-width: 100%;
+  min-height: 2.2rem; /* extra height for header buttons */
 }
 
 /* Thumbnail images in the secure uploader table */

--- a/Aurora/public/styles_light.css
+++ b/Aurora/public/styles_light.css
@@ -333,6 +333,11 @@ body {
   position: relative;
 }
 
+/* Extra space to place buttons above timestamp */
+.chat-user .bubble-header {
+  padding-top: 16px;
+}
+
 /* Date header separating chat days */
 .chat-date-header {
   text-align: center;
@@ -399,6 +404,7 @@ body {
 /* Individual user message within a chat bubble */
 .user-subbubble {
   max-width: 100%;
+  min-height: 2.2rem; /* extra height for header buttons */
 }
 
 /* Thumbnail images in the secure uploader table */


### PR DESCRIPTION
## Summary
- enlarge user chat subbubble height
- add padding for user bubble headers to let buttons sit above the timestamp

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68425e3ab6888323b1c4360051f898d4