### PR TITLE
Update image load scroll delay

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4809,7 +4809,7 @@ function addImageChatBubble(url, altText="", title=""){
   if(title) img.title = title;
   img.style.maxWidth = "min(100%, 400px)";
   img.style.height = "auto";
-  img.addEventListener('load', scrollChatToBottom);
+  img.addEventListener('load', () => setTimeout(scrollChatToBottom, 1000));
   botDiv.appendChild(img);
 
   seqDiv.appendChild(botDiv);


### PR DESCRIPTION
## Summary
- after an image finishes loading, wait one second before scrolling the chat to the bottom

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_b_6842783a30a8832382612da7847c4ae6