### PR TITLE
Update upscale script missing error

### DIFF
--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1967,8 +1967,15 @@ app.post("/api/upscale", async (req, res) => {
     }
 
     if (!fs.existsSync(scriptPath)) {
-      console.debug("[Server Debug] /api/upscale => script not found:", scriptPath);
-      return res.status(500).json({ error: "Upscale script missing" });
+      console.debug(
+        "[Server Debug] /api/upscale => script not found:",
+        scriptPath,
+      );
+      return res
+        .status(500)
+        .json({
+          error: `Upscale script missing. Expected at ${scriptPath} (set UPSCALE_SCRIPT_PATH to override).`,
+        });
     }
 
     const job = jobManager.createJob(scriptPath, [filePath], { cwd: scriptCwd, file });


### PR DESCRIPTION
## Summary
- clarify the default location of the upscale script in `server.js`

## Testing
- `npm run lint` in `Aurora`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684277141200832389abc671fc99f2a1