### PR TITLE
Fix AI model selector visibility

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -236,7 +236,7 @@
         <div id="modelTabsContainer" style="flex-wrap: wrap;display:none;gap:0.5rem;"></div>
         <button id="newModelTabBtn" style="display:none;">➕ Model</button>
         <!-- Added toggle for model tabs bar -->
-        <button id="toggleModelTabsBtn" hidden>Models</button>
+        <button id="toggleModelTabsBtn">Models</button>
       </div>
 
       <div id="chatMessages">
@@ -436,7 +436,7 @@
         </select>
       </label>
     </div>
-    <div style="margin-top:8px;" hidden>
+    <div style="margin-top:8px;">
       <label>AI Model:
         <select id="aiModelSelect">
           <!-- populated dynamically -->


### PR DESCRIPTION
## Summary
- unhide model tabs toggle button
- show AI model select dropdown in chat settings

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68427fd93e9c83239129c65b482db02b