### PR TITLE
Restore global AI model selector

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -167,7 +167,7 @@
       <a id="blueskyBtn" href="https://bsky.app/profile/alfeai.bsky.social" target="_blank" class="top-btn" title="AlfeAI on Bluesky">🦋</a>
       <button id="themeToggleBtn" class="top-btn" title="Toggle Theme">☀️</button>
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
-      <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings" style="display:none;">⚙️</button>
+      <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings">⚙️</button>
       <button id="aiFavoritesBtn" class="top-btn" title="AI Favorites" style="color: gold;">⭐</button>
       <button id="signupBtn" class="top-btn">Sign Up/Login</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
@@ -231,13 +231,7 @@
           <div id="modelHud" style="font-size:0.9rem; color:#aaa; margin-bottom:4px;"></div>
         </div>
 
-      <!-- New 'model tabs' section -->
-      <div id="modelTabs" style="display:flex; gap:0.5rem; align-items:center; margin-bottom:4px;">
-        <div id="modelTabsContainer" style="flex-wrap: wrap;display:none;gap:0.5rem;"></div>
-        <button id="newModelTabBtn" style="display:none;">➕ Model</button>
-        <!-- Added toggle for model tabs bar -->
-        <button id="toggleModelTabsBtn" hidden>Models</button>
-      </div>
+
 
       <div id="chatMessages">
         <div id="chatPlaceholder" style="text-align:center;margin:1rem 0;">
@@ -357,18 +351,6 @@
   </div>
 </div>
 
-<div id="addModelModal" class="modal">
-  <div class="modal-content">
-    <h2>Add Model Tab</h2>
-    <label>Select model:<br/>
-      <select id="favoriteModelSelect" style="width:100%;"></select>
-    </label>
-    <div class="modal-buttons">
-      <button id="addModelModalAddBtn">Add</button>
-      <button id="addModelModalCancelBtn">Cancel</button>
-    </div>
-  </div>
-</div>
 
 <div id="chatSettingsModal" class="modal">
   <div class="modal-content">
@@ -436,7 +418,7 @@
         </select>
       </label>
     </div>
-    <div style="margin-top:8px;" hidden>
+    <div style="margin-top:8px;">
       <label>AI Model:
         <select id="aiModelSelect">
           <!-- populated dynamically -->

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1685,17 +1685,23 @@ $$('#newTabTypeButtons .start-type-btn').forEach(btn => {
     await addNewTab();
   });
 });
-document.getElementById("addModelModalAddBtn").addEventListener("click", async () => {
-  const sel = document.getElementById("favoriteModelSelect");
-  const modelId = sel ? sel.value : "";
-  if(modelId){
-    await addModelTab(modelId);
-  }
-  hideModal(document.getElementById("addModelModal"));
-});
-document.getElementById("addModelModalCancelBtn").addEventListener("click", () => {
-  hideModal(document.getElementById("addModelModal"));
-});
+const addModelModalAddBtn = document.getElementById("addModelModalAddBtn");
+if(addModelModalAddBtn){
+  addModelModalAddBtn.addEventListener("click", async () => {
+    const sel = document.getElementById("favoriteModelSelect");
+    const modelId = sel ? sel.value : "";
+    if(modelId){
+      await addModelTab(modelId);
+    }
+    hideModal(document.getElementById("addModelModal"));
+  });
+}
+const addModelModalCancelBtn = document.getElementById("addModelModalCancelBtn");
+if(addModelModalCancelBtn){
+  addModelModalCancelBtn.addEventListener("click", () => {
+    hideModal(document.getElementById("addModelModal"));
+  });
+}
 document.getElementById("newSubroutineBtn").addEventListener("click", addNewSubroutine);
 document.getElementById("viewActionHooksBtn").addEventListener("click", () => {
   renderActionHooks();
@@ -2633,7 +2639,7 @@ async function chatSettingsSaveFlow() {
     const { provider: autoProvider } = parseProviderModel(modelName);
     console.log("[OBTAINED PROVIDER] => (global model removed in UI, fallback only)");
     console.log("[OBTAINED PROVIDER] =>", autoProvider);
-    $("#modelHud").textContent = "";
+    $("#modelHud").textContent = `Model: ${modelName}`;
   }
 
   hideModal($("#chatSettingsModal"));
@@ -3489,7 +3495,7 @@ thinArchiveIcon?.addEventListener("touchstart", ev => {
   console.log("[OBTAINED PROVIDER] => (global model removed in UI, fallback only)");
   const { provider: autoProvider } = parseProviderModel(modelName);
   console.log("[OBTAINED PROVIDER] =>", autoProvider);
-  $("#modelHud").textContent = "";
+  $("#modelHud").textContent = `Model: ${modelName}`;
 
   await loadTabs();
   await loadSubroutines();
@@ -3633,8 +3639,6 @@ thinArchiveIcon?.addEventListener("touchstart", ev => {
 
   initChatScrollLoading();
 
-  // Initialize model tabs
-  initModelTabs();
   updatePageTitle();
 
   // -----------------------------------------------------------------------
@@ -4351,24 +4355,27 @@ async function saveModelTabs(){
   await setSetting("model_tabs", modelTabs);
 }
 
-document.getElementById("toggleModelTabsBtn").addEventListener("click", async () => {
-  const cont = document.getElementById("modelTabsContainer");
-  const newBtn = document.getElementById("newModelTabBtn");
-  const toggleBtn = document.getElementById("toggleModelTabsBtn");
-  if(modelTabsBarVisible){
-    if(cont) cont.style.display = "none";
-    if(newBtn) newBtn.style.display = "none";
-    toggleBtn.textContent = "Model";
-    modelTabsBarVisible = false;
-    await setSetting("model_tabs_bar_visible", false);
-  } else {
-    if(cont) cont.style.display = "";
-    if(newBtn) newBtn.style.display = "";
-    toggleBtn.textContent = "Minimize model tabs bar";
-    modelTabsBarVisible = true;
-    await setSetting("model_tabs_bar_visible", true);
-  }
-});
+const toggleModelTabsBtn = document.getElementById("toggleModelTabsBtn");
+if(toggleModelTabsBtn){
+  toggleModelTabsBtn.addEventListener("click", async () => {
+    const cont = document.getElementById("modelTabsContainer");
+    const newBtn = document.getElementById("newModelTabBtn");
+    const toggleBtn = document.getElementById("toggleModelTabsBtn");
+    if(modelTabsBarVisible){
+      if(cont) cont.style.display = "none";
+      if(newBtn) newBtn.style.display = "none";
+      toggleBtn.textContent = "Model";
+      modelTabsBarVisible = false;
+      await setSetting("model_tabs_bar_visible", false);
+    } else {
+      if(cont) cont.style.display = "";
+      if(newBtn) newBtn.style.display = "";
+      toggleBtn.textContent = "Minimize model tabs bar";
+      modelTabsBarVisible = true;
+      await setSetting("model_tabs_bar_visible", true);
+    }
+  });
+}
 
 // ----------------------------------------------------------------------
 // NEW: "Change Sterling Branch" button event + modal logic
@@ -4522,6 +4529,8 @@ async function saveGlobalAiSettings(){
   const svc = document.getElementById("globalAiServiceSelect").value;
   const model = document.getElementById("globalAiModelSelect").value;
   await setSettings({ ai_service: svc, ai_model: model });
+  modelName = model || "unknown";
+  document.getElementById("modelHud").textContent = `Model: ${modelName}`;
   hideModal(document.getElementById("globalAiSettingsModal"));
 }
 


### PR DESCRIPTION
## Summary
- show global AI settings button in the top-right bar
- unhide AI model dropdown in Chat Settings
- drop model tabs UI and related modal
- update JS to show selected model in HUD and handle removed model tabs

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684282a2c9d483238a2c30cb86c4f89b