### PR TITLE
Restrict global AI model list to favorites

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4510,9 +4510,14 @@ async function openGlobalAiSettings(){
       const data = await resp.json();
       const sel = document.getElementById("globalAiModelSelect");
       sel.innerHTML = "";
-      (data.models || []).forEach(m => {
-        sel.appendChild(new Option(`${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`, m.id));
-      });
+      const favs = (data.models || []).filter(m => m.favorite);
+      if(favs.length === 0){
+        sel.appendChild(new Option("(no favorites)", ""));
+      } else {
+        favs.forEach(m => {
+          sel.appendChild(new Option(`${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`, m.id));
+        });
+      }
       const curModel = await getSetting("ai_model");
       if(curModel) sel.value = curModel;
     }


### PR DESCRIPTION
## Summary
- limit selectable AI models in global AI settings to only favorite models

## Testing
- `npm run lint` *(fails: no linter configured)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6842882fec5c8323b1ec864a2c666fb1