### PR TITLE
Restrict global AI settings to OpenRouter

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -453,8 +453,7 @@
     <h2>Global AI Settings</h2>
     <div style="margin-top:8px;">
       <label>AI Service:
-        <select id="globalAiServiceSelect">
-          <option value="openai">OpenAI</option>
+        <select id="globalAiServiceSelect" disabled>
           <option value="openrouter" selected>OpenRouter</option>
         </select>
       </label>


### PR DESCRIPTION
## Summary
- limit the Global AI Service dropdown to OpenRouter only

## Testing
- `npm run lint` in `Aurora`

------
https://chatgpt.com/codex/tasks/task_b_68433e9296188323aff45a45a8a2c178