### PR TITLE
Hide prices in model dropdown

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4551,7 +4551,7 @@ async function openGlobalAiSettings(){
         sel.appendChild(new Option("(no favorites)", ""));
       } else {
         favs.forEach(m => {
-          sel.appendChild(new Option(`${m.id} (limit ${m.tokenLimit}, in ${m.inputCost}, out ${m.outputCost})`, m.id));
+          sel.appendChild(new Option(`${m.id} (limit ${m.tokenLimit})`, m.id));
         });
       }
       const curModel = await getSetting("ai_model");


### PR DESCRIPTION
## Summary
- suppress price info for models in the Global AI Settings dropdown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68433ee621448323aa040136adad9a1d