### PR TITLE
Add settings modal to Aurora UI

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -169,6 +169,7 @@
       <button id="chatSettingsBtn" class="top-btn" title="Chat Settings" style="display:none;">⚙️</button>
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings">🤖</button>
       <button id="aiFavoritesBtn" class="top-btn" title="AI Favorites" style="color: gold; display:none;">⭐</button>
+      <button id="settingsBtn" class="top-btn" title="Settings">⚙️</button>
       <button id="signupBtn" class="top-btn">Sign Up/Login</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
@@ -675,6 +676,17 @@
       </div>
       <p id="totpEnabledMsg" style="display:none;">2FA Enabled</p>
     </div>
+    <div class="modal-buttons">
+      <button id="accountLogoutBtn">Logout</button>
+      <button id="accountCloseBtn">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- Settings modal -->
+<div id="settingsModal" class="modal">
+  <div class="modal-content">
+    <h2>Settings</h2>
     <div id="timezoneSection" style="margin-top:10px;">
       <label>Timezone:<br/>
         <input type="text" id="accountTimezone" style="width:100%;" placeholder="e.g., America/Chicago" />
@@ -688,8 +700,7 @@
       <label><input type="checkbox" id="accountAutoScrollCheck"/> Keep chat pinned to bottom</label>
     </div>
     <div class="modal-buttons">
-      <button id="accountLogoutBtn">Logout</button>
-      <button id="accountCloseBtn">Close</button>
+      <button id="settingsCloseBtn">Close</button>
     </div>
   </div>
 </div>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -262,8 +262,6 @@ function openAccountModal(e){
   if(accountInfo){
     const emailEl = document.getElementById("accountEmail");
     if(emailEl) emailEl.textContent = accountInfo.email;
-    const tzEl = document.getElementById('accountTimezone');
-    if(tzEl) tzEl.value = accountInfo.timezone || '';
     const enabledMsg = document.getElementById('totpEnabledMsg');
     const enableBtn = document.getElementById('enableTotpBtn');
     if(accountInfo.totpEnabled){
@@ -273,6 +271,15 @@ function openAccountModal(e){
       if(enabledMsg) enabledMsg.style.display = 'none';
       if(enableBtn) enableBtn.style.display = 'inline-block';
     }
+  }
+  showModal(document.getElementById("accountModal"));
+}
+
+function openSettingsModal(e){
+  if(e) e.preventDefault();
+  if(accountInfo){
+    const tzEl = document.getElementById('accountTimezone');
+    if(tzEl) tzEl.value = accountInfo.timezone || '';
     const loopSection = document.getElementById('imageLoopSection');
     const loopCheck = document.getElementById('accountImageLoopCheck');
     if(loopSection && loopCheck){
@@ -280,12 +287,12 @@ function openAccountModal(e){
       loopSection.style.display = allowed ? 'block' : 'none';
       loopCheck.checked = imageLoopEnabled;
     }
-    const autoScrollCheck = document.getElementById('accountAutoScrollCheck');
-    if(autoScrollCheck){
-      autoScrollCheck.checked = chatAutoScroll;
-    }
   }
-  showModal(document.getElementById("accountModal"));
+  const autoScrollCheck = document.getElementById('accountAutoScrollCheck');
+  if(autoScrollCheck){
+    autoScrollCheck.checked = chatAutoScroll;
+  }
+  showModal(document.getElementById("settingsModal"));
 }
 
 function updateAccountButton(info){
@@ -1853,6 +1860,18 @@ if(accountCloseBtn){
 const accountLogoutBtn = document.getElementById("accountLogoutBtn");
 if(accountLogoutBtn){
   accountLogoutBtn.addEventListener("click", logout);
+}
+
+const settingsBtn = document.getElementById("settingsBtn");
+if(settingsBtn){
+  settingsBtn.addEventListener("click", openSettingsModal);
+}
+
+const settingsCloseBtn = document.getElementById("settingsCloseBtn");
+if(settingsCloseBtn){
+  settingsCloseBtn.addEventListener("click", () =>
+    hideModal(document.getElementById("settingsModal"))
+  );
 }
 
 const enableTotpBtn = document.getElementById('enableTotpBtn');


### PR DESCRIPTION
## Summary
- introduce new settings modal in aurora.html
- move timezone and chat options from Account modal
- add Settings button
- support new modal in main.js

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684376d88e208323ab12a680fc1e8b06