### PR TITLE
Add per-chat AI model selection

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -394,7 +394,7 @@
     <br/>
     <div style="margin-top:8px;">
       <label>AI Service:
-        <select id="aiServiceSelect">
+        <select id="tabAiServiceSelect">
           <option value="openai">OpenAI</option>
           <option value="openrouter" selected>OpenRouter</option>
         </select>
@@ -410,7 +410,7 @@
     </div>
     <div style="margin-top:8px;">
       <label>Provider:
-        <select id="aiModelProviderSelect">
+        <select id="tabAiModelProviderSelect">
           <option value="">All Providers</option>
           <option value="openai">openai</option>
           <option value="openrouter">openrouter</option>
@@ -420,7 +420,7 @@
     </div>
     <div style="margin-top:8px;">
       <label>AI Model:
-        <select id="aiModelSelect">
+        <select id="tabAiModelSelect">
           <!-- populated dynamically -->
         </select>
         <label style="margin-left:8px;"><input type="checkbox" id="favoritesOnlyModelCheck" /> Favorites Only</label>
@@ -686,6 +686,19 @@
     </div>
     <div id="autoScrollSection" style="margin-top:10px;">
       <label><input type="checkbox" id="accountAutoScrollCheck"/> Keep chat pinned to bottom</label>
+    </div>
+    <div id="aiSettingsSection" style="margin-top:10px;">
+      <label>AI Service:<br/>
+        <select id="accountAiServiceSelect">
+          <option value="openai">OpenAI</option>
+          <option value="openrouter">OpenRouter</option>
+          <option value="deepseek">DeepSeek</option>
+        </select>
+      </label>
+      <label style="margin-top:8px; display:block;">AI Model:<br/>
+        <select id="accountAiModelSelect"></select>
+      </label>
+      <button id="accountAiSaveBtn" style="margin-top:8px;">Save AI Settings</button>
     </div>
     <div class="modal-buttons">
       <button id="accountLogoutBtn">Logout</button>


### PR DESCRIPTION
## Summary
- allow storing an `ai_model` for each chat tab
- move global AI model/service controls into the Account modal
- support updating a tab's model via `/api/chat/tabs/model`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684376ca01b88323a0f0c908b8e74950