### PR TITLE
Fix final upscale path parsing

### DIFF
--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -180,7 +180,8 @@ export default class PrintifyJobQueue {
       job.status = jmJob.status;
       job.resultPath = jmJob.resultPath;
       if (job.type === 'upscale') {
-        const m = jmJob.log.match(/Final output saved to:\s*(.+)/i);
+        const matches = [...jmJob.log.matchAll(/Final output saved to:\s*(.+)/gi)];
+        const m = matches[matches.length - 1];
         if (m) {
           job.resultPath = m[1].trim();
           if (this.db) {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -1989,7 +1989,8 @@ app.post("/api/upscale", async (req, res) => {
 
     const job = jobManager.createJob(scriptPath, [filePath], { cwd: scriptCwd, file });
     jobManager.addDoneListener(job, () => {
-      const m = job.log.match(/Final output saved to:\s*(.+)/i);
+      const matches = [...job.log.matchAll(/Final output saved to:\s*(.+)/gi)];
+      const m = matches[matches.length - 1];
       if (m) {
         job.resultPath = m[1].trim();
         console.debug("[Server Debug] Recorded resultPath =>", job.resultPath);
@@ -2025,7 +2026,7 @@ app.post("/api/upscale", async (req, res) => {
             // ----- Copy RIBT output for final upscale -----
             const upscaleName = `${dbId || base}_upscale${ext}`;
             const upscaleDest = path.join(uploadsDir, upscaleName);
-            const ribtCopySrc = '/home/syl/git/LogisticaRIBT/output.png';
+            const ribtCopySrc = ribtOutput;
             if (fs.existsSync(ribtCopySrc)) {
               fs.copyFileSync(ribtCopySrc, upscaleDest);
               job.resultPath = upscaleDest;


### PR DESCRIPTION
## Summary
- capture the last `Final output saved to:` line so the correct image path is used

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6843b472e8188323a499732b948fd3de