### PR TITLE
Fix printify path resolution

### DIFF
--- a/Aurora/public/Image.html
+++ b/Aurora/public/Image.html
@@ -332,9 +332,10 @@
         const choice = document.querySelector('input[name="printifyVariant"]:checked');
         const variant = choice ? choice.value : (nobgFile ? 'nobg' : 'normal');
         const targetFile = variant === 'nobg' ? nobgFile : upscaledFile;
-        console.debug('Submit to Printify clicked with file =>', targetFile);
+        const targetPath = variant === 'nobg' ? nobgPath : upscaledPath;
+        console.debug('Submit to Printify clicked with file =>', targetPath);
         terminalEl.textContent = '';
-        if(!targetFile){
+        if(!targetFile && !targetPath){
           terminalEl.textContent = 'Upscaled 4096 image not available.';
           console.debug('Printify aborted => upscaled image missing');
           return;
@@ -344,7 +345,7 @@
           const res = await fetch('/api/printify', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ file: targetFile })
+            body: JSON.stringify({ file: targetPath || targetFile })
           });
           console.debug('Received response =>', res.status);
           const data = await res.json().catch(() => ({}));

--- a/Aurora/src/printifyJobQueue.js
+++ b/Aurora/src/printifyJobQueue.js
@@ -98,7 +98,9 @@ export default class PrintifyJobQueue {
     job.status = 'running';
     this._saveJobs();
 
-    let filePath = path.join(this.uploadsDir, job.file);
+    let filePath = path.isAbsolute(job.file)
+      ? job.file
+      : path.join(this.uploadsDir, job.file);
     let script = '';
     if (job.type === 'upscale') {
       script = this.upscaleScript;
@@ -106,27 +108,30 @@ export default class PrintifyJobQueue {
       script = this.printifyScript;
       const ext = path.extname(filePath);
       const base = path.basename(filePath, ext);
+      const searchDir = path.isAbsolute(job.file)
+        ? path.dirname(filePath)
+        : this.uploadsDir;
       const normalCandidates = [
-        ...(job.dbId ? [path.join(this.uploadsDir, `${job.dbId}_upscale${ext}`)] : []),
-        path.join(this.uploadsDir, `${base}_4096${ext}`),
-        path.join(this.uploadsDir, `${base}-4096${ext}`),
-        path.join(this.uploadsDir, `${base}_upscaled${ext}`),
-        path.join(this.uploadsDir, `${base}-upscaled${ext}`)
+        ...(job.dbId ? [path.join(searchDir, `${job.dbId}_upscale${ext}`)] : []),
+        path.join(searchDir, `${base}_4096${ext}`),
+        path.join(searchDir, `${base}-4096${ext}`),
+        path.join(searchDir, `${base}_upscaled${ext}`),
+        path.join(searchDir, `${base}-upscaled${ext}`)
       ];
       const nobgCandidates = [
-        ...(job.dbId ? [path.join(this.uploadsDir, `${job.dbId}_nobg${ext}`)] : []),
-        path.join(this.uploadsDir, `${base}_4096_nobg${ext}`),
-        path.join(this.uploadsDir, `${base}-4096-nobg${ext}`),
-        path.join(this.uploadsDir, `${base}_upscaled_nobg${ext}`),
-        path.join(this.uploadsDir, `${base}-upscaled-nobg${ext}`),
-        path.join(this.uploadsDir, `${base}_4096_no_bg${ext}`),
-        path.join(this.uploadsDir, `${base}-4096-no_bg${ext}`),
-        path.join(this.uploadsDir, `${base}_4096-no-bg${ext}`),
-        path.join(this.uploadsDir, `${base}-4096-no-bg${ext}`),
-        path.join(this.uploadsDir, `${base}_upscaled_no_bg${ext}`),
-        path.join(this.uploadsDir, `${base}-upscaled-no_bg${ext}`),
-        path.join(this.uploadsDir, `${base}_upscaled-no-bg${ext}`),
-        path.join(this.uploadsDir, `${base}-upscaled-no-bg${ext}`)
+        ...(job.dbId ? [path.join(searchDir, `${job.dbId}_nobg${ext}`)] : []),
+        path.join(searchDir, `${base}_4096_nobg${ext}`),
+        path.join(searchDir, `${base}-4096-nobg${ext}`),
+        path.join(searchDir, `${base}_upscaled_nobg${ext}`),
+        path.join(searchDir, `${base}-upscaled-nobg${ext}`),
+        path.join(searchDir, `${base}_4096_no_bg${ext}`),
+        path.join(searchDir, `${base}-4096-no_bg${ext}`),
+        path.join(searchDir, `${base}_4096-no-bg${ext}`),
+        path.join(searchDir, `${base}-4096-no-bg${ext}`),
+        path.join(searchDir, `${base}_upscaled_no_bg${ext}`),
+        path.join(searchDir, `${base}-upscaled-no_bg${ext}`),
+        path.join(searchDir, `${base}_upscaled-no-bg${ext}`),
+        path.join(searchDir, `${base}-upscaled-no-bg${ext}`)
       ];
 
       const findFirst = (cands) => {


### PR DESCRIPTION
## Summary
- send full image path when submitting to printify
- search for variant images in the same folder when an absolute path is provided

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6843b8c585e883238e06b936403aacb5