### PR TITLE
Add auth tabs and confirm password

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -170,7 +170,7 @@
       <button id="globalAiSettingsBtn" class="top-btn" title="Global AI Settings">🤖</button>
       <button id="aiFavoritesBtn" class="top-btn" title="AI Favorites" style="color: gold; display:none;">⭐</button>
       <button id="settingsBtn" class="top-btn" title="Settings">⚙️</button>
-      <button id="signupBtn" class="top-btn">Sign Up/Login</button>
+      <button id="signupBtn" class="top-btn">Sign Up / Login</button>
 <!--    <a id="changelogBtn" href="/changelog.html" class="top-btn" target="_blank">Changelog</a>-->
     </div>
 
@@ -628,8 +628,11 @@
 <!-- Login/Signup modal -->
 <div id="authModal" class="modal">
   <div class="modal-content">
+    <div id="authTabs" style="display:flex; gap:0.5rem; margin-bottom:1rem;">
+      <button id="loginTab" class="view-tab active">Login</button>
+      <button id="signupTab" class="view-tab">Sign Up</button>
+    </div>
     <div id="loginForm">
-      <h2>Login</h2>
       <label>Email:<br/>
         <input type="email" id="loginEmail" style="width:100%;" />
       </label>
@@ -646,12 +649,14 @@
       </div>
     </div>
     <div id="signupForm" style="display:none;">
-      <h2>Create Account</h2>
       <label>Email:<br/>
         <input type="email" id="signupEmail" style="width:100%;" />
       </label>
       <label style="margin-top:8px;">Password:<br/>
         <input type="password" id="signupPassword" style="width:100%;" />
+      </label>
+      <label style="margin-top:8px;">Confirm Password:<br/>
+        <input type="password" id="signupConfirm" style="width:100%;" />
       </label>
       <div class="modal-buttons">
         <button id="signupSubmitBtn">Register</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -236,6 +236,10 @@ function showSignupForm(){
   const signup = document.getElementById('signupForm');
   if(login) login.style.display = 'none';
   if(signup) signup.style.display = 'block';
+  const loginTab = document.getElementById('loginTab');
+  const signupTab = document.getElementById('signupTab');
+  if(loginTab) loginTab.classList.remove('active');
+  if(signupTab) signupTab.classList.add('active');
 }
 
 function showLoginForm(){
@@ -243,6 +247,10 @@ function showLoginForm(){
   const signup = document.getElementById('signupForm');
   if(signup) signup.style.display = 'none';
   if(login) login.style.display = 'block';
+  const loginTab = document.getElementById('loginTab');
+  const signupTab = document.getElementById('signupTab');
+  if(signupTab) signupTab.classList.remove('active');
+  if(loginTab) loginTab.classList.add('active');
 }
 
 function openSignupModal(e){
@@ -312,7 +320,7 @@ function updateAccountButton(info){
     }
   } else {
     accountInfo = null;
-    btn.textContent = "Sign Up/Login";
+    btn.textContent = "Sign Up / Login";
     btn.addEventListener("click", openLoginModal);
     if(favBtn){
       favBtn.style.display = "none";
@@ -1766,8 +1774,13 @@ if (signupSubmitBtn) {
   signupSubmitBtn.addEventListener("click", async () => {
     const email = document.getElementById("signupEmail").value.trim();
     const password = document.getElementById("signupPassword").value;
+    const confirm = document.getElementById("signupConfirm")?.value;
     if(!email || !password){
       showToast("Email and password required");
+      return;
+    }
+    if(confirm !== undefined && password !== confirm){
+      showToast("Passwords do not match");
       return;
     }
     try {
@@ -1806,6 +1819,16 @@ if (showSignupBtn) {
 const showLoginBtn = document.getElementById("showLoginBtn");
 if (showLoginBtn) {
   showLoginBtn.addEventListener("click", showLoginForm);
+}
+
+const loginTabBtn = document.getElementById("loginTab");
+if (loginTabBtn) {
+  loginTabBtn.addEventListener("click", showLoginForm);
+}
+
+const signupTabBtn = document.getElementById("signupTab");
+if (signupTabBtn) {
+  signupTabBtn.addEventListener("click", showSignupForm);
 }
 
 const loginSubmitBtn = document.getElementById("loginSubmitBtn");


### PR DESCRIPTION
## Summary
- tweak signup button text
- add tabbed login/signup UI with confirm password field
- highlight active tab via JS
- validate confirm password in signup handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68453a6e2b788323ab0cc1b4a47714a6