### PR TITLE
Set signup tab as default in auth modal

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -321,7 +321,7 @@ function updateAccountButton(info){
   } else {
     accountInfo = null;
     btn.textContent = "Sign Up / Login";
-    btn.addEventListener("click", openLoginModal);
+  btn.addEventListener("click", openSignupModal);
     if(favBtn){
       favBtn.style.display = "none";
     }
@@ -1767,7 +1767,7 @@ if (subscribeCloseBtn) {
 
 const signupBtn = document.getElementById("signupBtn");
 if (signupBtn) {
-  signupBtn.addEventListener("click", openLoginModal);
+  signupBtn.addEventListener("click", openSignupModal);
 }
 const signupSubmitBtn = document.getElementById("signupSubmitBtn");
 if (signupSubmitBtn) {


### PR DESCRIPTION
## Summary
- default signup modal view when accessing the auth modal

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68453d23af0c8323ad490a11a3fa60b2