### PR TITLE
Add Node HTTPS redirect for alfe.sh

### DIFF
--- a/AlfeRedirect/README.md
+++ b/AlfeRedirect/README.md
@@ -1,0 +1,25 @@
+# Alfe.sh Redirect
+
+Simple Node.js server that listens on HTTPS port `3001` and redirects all traffic to [https://mvp2.alfe.sh](https://mvp2.alfe.sh).
+
+## Setup
+1. Ensure Node.js and npm are installed.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+## Running
+Start the server with:
+```bash
+npm start
+```
+
+### Environment variables
+Set `HTTPS_KEY_PATH` and `HTTPS_CERT_PATH` to the SSL key and certificate files for `alfe.sh`.
+Run `../setup_certbot.sh alfe.sh <email>` to generate these files with Let's Encrypt.
+
+If you want to accept connections on the standard HTTPS port without root, forward port `443` to `3001`:
+```bash
+sudo ../forward_port_443.sh 3001
+```

--- a/AlfeRedirect/package.json
+++ b/AlfeRedirect/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "alfe-sh-redirect",
+  "version": "1.0.0",
+  "description": "HTTPS redirect from alfe.sh:3001 to https://mvp2.alfe.sh",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/AlfeRedirect/run.sh
+++ b/AlfeRedirect/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm start

--- a/AlfeRedirect/server.js
+++ b/AlfeRedirect/server.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const https = require('https');
+const express = require('express');
+
+const PORT = process.env.PORT || 3001;
+const keyPath = process.env.HTTPS_KEY_PATH;
+const certPath = process.env.HTTPS_CERT_PATH;
+
+const app = express();
+
+app.use((req, res) => {
+  res.redirect('https://mvp2.alfe.sh');
+});
+
+if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
+  const options = {
+    key: fs.readFileSync(keyPath),
+    cert: fs.readFileSync(certPath),
+  };
+  https.createServer(options, app).listen(PORT, () => {
+    console.log(`Redirect server running on https://alfe.sh:${PORT}`);
+  });
+} else {
+  console.error('Missing SSL certificates. Set HTTPS_KEY_PATH and HTTPS_CERT_PATH');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `AlfeRedirect` project for HTTPS redirect on port 3001
- document how to install deps, generate certs and run

## Testing
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_b_6845466662f0832392306fd29a67fefe