### PR TITLE
Remove reverse-engineering bullet from TOS

### DIFF
--- a/Aurora/public/terms.html
+++ b/Aurora/public/terms.html
@@ -48,8 +48,6 @@ Use the Service to violate any law or regulation.
 
 Upload or generate unlawful, hateful, harassing, or discriminatory content.
 
-Attempt to reverse-engineer or extract model parameters or proprietary source code.
-
 Circumvent rate limits or security measures.
 
 Use the Service to create or disseminate deceptive, false, or defamatory information.


### PR DESCRIPTION
## Summary
- update `terms.html` to remove reference to reverse-engineering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684547b2728083238b79abaf1cf417c6