### PR TITLE
Restrict save on Global AI settings

### DIFF
--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -4605,6 +4605,12 @@ async function openGlobalAiSettings(){
   } catch(e){
     console.error("Error opening global AI settings:", e);
   } finally {
+    const saveBtn = document.getElementById("globalAiSettingsSaveBtn");
+    if(saveBtn){
+      const allowed = accountInfo && accountInfo.id === 1;
+      saveBtn.disabled = !allowed;
+      saveBtn.title = allowed ? "" : "Restricted";
+    }
     hidePageLoader();
     showModal(document.getElementById("globalAiSettingsModal"));
   }


### PR DESCRIPTION
## Summary
- prevent non-admin users from saving global AI model settings
- show `Restricted` tooltip when save button is disabled

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684549e8e53c832381c1ee4ff70dbaa0