### PR TITLE
Remove personalize user experiences from privacy policy

### DIFF
--- a/Aurora/public/privacy.html
+++ b/Aurora/public/privacy.html
@@ -43,8 +43,6 @@ We use collected data to:
 
 Operate and improve our services
 
-Personalize user experiences
-
 Provide support and respond to inquiries
 
 Secure our systems and detect misuse


### PR DESCRIPTION
## Summary
- delete the line "Personalize user experiences" from the privacy policy

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68454d7556408323973b7ea5af8a5807