### PR TITLE
Add privacy link to cookies page

### DIFF
--- a/Aurora/public/cookies.html
+++ b/Aurora/public/cookies.html
@@ -11,6 +11,6 @@
   <p>Your theme settings and feature flags are saved to <code>localStorage</code> along with whether you've accepted this notice.</p>
   <p>These cookies are never used for advertising or tracking outside of this application.</p>
   <hr>
-  <p>Read our <a href="terms.html" target="_blank">Terms of Service</a>.</p>
+  <p>Read our <a href="terms.html" target="_blank">Terms of Service</a> and <a href="privacy.html" target="_blank">Privacy Policy</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to Privacy Policy from cookies page

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68454d9f3f04832387cd28e07991096c