### PR TITLE
Add HTTP redirect and forwarding helper

### DIFF
--- a/AlfeRedirect/README.md
+++ b/AlfeRedirect/README.md
@@ -19,6 +19,8 @@ npm start
 Set `HTTPS_KEY_PATH` and `HTTPS_CERT_PATH` to the SSL key and certificate files for `alfe.sh`.
 Run `../setup_certbot.sh alfe.sh <email>` to generate these files with Let's Encrypt.
 
+`HTTP_PORT` sets the port for the HTTP redirect server (default `80`). Use `../forward_port_80.sh` to forward port 80 to this value when running without root.
+
 If you want to accept connections on the standard HTTPS port without root, forward port `443` to `3001`:
 ```bash
 sudo ../forward_port_443.sh 3001

--- a/AlfeRedirect/server.js
+++ b/AlfeRedirect/server.js
@@ -1,8 +1,10 @@
 const fs = require('fs');
+const http = require('http');
 const https = require('https');
 const express = require('express');
 
 const PORT = process.env.PORT || 3001;
+const HTTP_PORT = process.env.HTTP_PORT || 80;
 const keyPath = process.env.HTTPS_KEY_PATH;
 const certPath = process.env.HTTPS_CERT_PATH;
 
@@ -19,6 +21,13 @@ if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
   };
   https.createServer(options, app).listen(PORT, () => {
     console.log(`Redirect server running on https://alfe.sh:${PORT}`);
+  });
+
+  http.createServer((req, res) => {
+    res.writeHead(301, { Location: 'https://mvp2.alfe.sh' });
+    res.end();
+  }).listen(HTTP_PORT, () => {
+    console.log(`HTTP redirect server on port ${HTTP_PORT}`);
   });
 } else {
   console.error('Missing SSL certificates. Set HTTPS_KEY_PATH and HTTPS_CERT_PATH');

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
 import https from "https";
+import http from "http";
 import GitHubClient from "./githubClient.js";
 import TaskQueue from "./taskQueue.js";
 import TaskDBLocal from "./taskDb.js";
@@ -2865,6 +2866,7 @@ const PORT =
   process.env.AURORA_PORT ||
   process.env.PORT ||
   3000;
+const HTTP_PORT = process.env.HTTP_PORT || 80;
 const keyPath = process.env.HTTPS_KEY_PATH;
 const certPath = process.env.HTTPS_CERT_PATH;
 
@@ -2879,6 +2881,14 @@ if (keyPath && certPath && fs.existsSync(keyPath) && fs.existsSync(certPath)) {
   };
   https.createServer(options, app).listen(PORT, () => {
     console.log(`[TaskQueue] HTTPS server running on port ${PORT}`);
+  });
+
+  http.createServer((req, res) => {
+    const host = req.headers.host ? req.headers.host.split(":")[0] : "";
+    res.writeHead(301, { Location: `https://${host}${req.url}` });
+    res.end();
+  }).listen(HTTP_PORT, () => {
+    console.log(`[TaskQueue] HTTP redirect server running on port ${HTTP_PORT}`);
   });
 } else {
   app.listen(PORT, () => {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Set `HTTPS_KEY_PATH` and `HTTPS_CERT_PATH` to the SSL key and certificate files
 to enable HTTPS across the included servers. If the files are missing the
 services fall back to HTTP.
 
+`HTTP_PORT` controls the port used for the HTTP redirect server (default: `80`).
+Forward port `80` to this value if running without root privileges.
+
 You can quickly obtain free certificates from Let's Encrypt by running the
 `setup_certbot.sh` script. It installs Certbot and generates the key and
 certificate files for the domain you specify.
@@ -47,3 +50,12 @@ sudo ./forward_port_443.sh 3000
 Replace `3000` with your chosen `AURORA_PORT`. After adding the rule, start the
 server normally and clients can connect using `https://your-domain/` on port
 `443` while the Node.js process continues to run on the higher port.
+
+To redirect plain HTTP traffic to HTTPS without running as root, forward port `80`
+to your chosen `HTTP_PORT`:
+
+```bash
+sudo ./forward_port_80.sh 8080
+```
+
+Then set `HTTP_PORT=8080` when running the server.

--- a/forward_port_80.sh
+++ b/forward_port_80.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# forward_port_80.sh - Forward port 80 to a higher user port using iptables
+# Usage: sudo ./forward_port_80.sh <target_port>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: sudo $0 <target_port>" >&2
+  exit 1
+fi
+
+TARGET_PORT="$1"
+
+# Forward incoming HTTP traffic to the specified port
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port "$TARGET_PORT"
+
+echo "Forwarding HTTP (80) -> $TARGET_PORT"


### PR DESCRIPTION
## Summary
- add HTTP redirect servers for Aurora and AlfeRedirect
- include script to forward port 80 when running without root
- document new HTTP_PORT variable and forwarding helper

## Testing
- `npm test` in AutoPR
- `npm test` in VMRunner *(fails: no test specified)*
- `npm test` in Aurora *(fails: missing script)*
- `npm test` in Sterling *(fails: missing script)*
- `npm test` in AlfeRedirect *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68454f96313883238322f12e1b30b62c