### PR TITLE
Update privacy policy subprocessors section

### DIFF
--- a/Aurora/public/privacy.html
+++ b/Aurora/public/privacy.html
@@ -54,7 +54,7 @@ We do not use your content to train our models unless you have explicitly opted 
 
 We do not sell or rent personal data. We may share information only:
 
-With third-party data processors—defined as service providers who process data on our behalf—under strict confidentiality and security obligations. A current list of subprocessors is available upon request or via our Subprocessor Disclosure Page
+With third-party data processors—defined as service providers who process data on our behalf—under strict confidentiality and security obligations. This currently includes OpenRouter and OpenAI for AI data processing. We do not yet maintain a separate Subprocessor Disclosure Page, but you can request a full list of subprocessors by contacting legal@alfe.sh.
 
 To comply with legal obligations or enforce our terms
 


### PR DESCRIPTION
## Summary
- clarify subprocessors in privacy policy
- mention OpenRouter and OpenAI

## Testing
- `sed -n '52,66p' Aurora/public/privacy.html`

------
https://chatgpt.com/codex/tasks/task_b_684550d5b4cc8323856d68e2c9a0e11e