### PR TITLE
Add password change option

### DIFF
--- a/Aurora/public/aurora.html
+++ b/Aurora/public/aurora.html
@@ -682,6 +682,21 @@
       </div>
       <p id="totpEnabledMsg" style="display:none;">2FA Enabled</p>
     </div>
+    <div id="passwordSection" style="margin-top:10px;">
+      <button id="showChangePasswordBtn">Change Password</button>
+      <div id="passwordForm" style="display:none; margin-top:10px;">
+        <label>Current Password:<br/>
+          <input type="password" id="currentPassword" style="width:100%;" />
+        </label>
+        <label style="margin-top:8px;">New Password:<br/>
+          <input type="password" id="newPassword" style="width:100%;" />
+        </label>
+        <label style="margin-top:8px;">Confirm New Password:<br/>
+          <input type="password" id="confirmPassword" style="width:100%;" />
+        </label>
+        <button id="changePasswordBtn" style="margin-top:8px;">Save</button>
+      </div>
+    </div>
     <div class="modal-buttons">
       <button id="accountLogoutBtn">Logout</button>
       <button id="accountCloseBtn">Close</button>

--- a/Aurora/public/main.js
+++ b/Aurora/public/main.js
@@ -1973,6 +1973,48 @@ if(timezoneSaveBtn){
   });
 }
 
+const showChangePasswordBtn = document.getElementById('showChangePasswordBtn');
+const passwordForm = document.getElementById('passwordForm');
+if(showChangePasswordBtn && passwordForm){
+  showChangePasswordBtn.addEventListener('click', () => {
+    passwordForm.style.display = 'block';
+    showChangePasswordBtn.style.display = 'none';
+  });
+}
+
+const changePasswordBtn = document.getElementById('changePasswordBtn');
+if(changePasswordBtn){
+  changePasswordBtn.addEventListener('click', async () => {
+    const current = document.getElementById('currentPassword').value;
+    const pw = document.getElementById('newPassword').value;
+    const confirm = document.getElementById('confirmPassword').value;
+    if(!current || !pw){
+      showToast('All fields required');
+      return;
+    }
+    if(pw !== confirm){
+      showToast('Passwords do not match');
+      return;
+    }
+    const resp = await fetch('/api/account/password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentPassword: current, newPassword: pw })
+    });
+    const data = await resp.json().catch(() => null);
+    if(resp.ok && data && data.success){
+      showToast('Password updated');
+      passwordForm.style.display = 'none';
+      showChangePasswordBtn.style.display = 'inline-block';
+      document.getElementById('currentPassword').value = '';
+      document.getElementById('newPassword').value = '';
+      document.getElementById('confirmPassword').value = '';
+    } else {
+      showToast(data?.error || 'Failed to update password');
+    }
+  });
+}
+
 const accountImageLoopCheck = document.getElementById('accountImageLoopCheck');
 if(accountImageLoopCheck){
   accountImageLoopCheck.addEventListener('change', () => {

--- a/Aurora/src/server.js
+++ b/Aurora/src/server.js
@@ -947,6 +947,22 @@ app.post("/api/account/timezone", (req, res) => {
   res.json({ success: true });
 });
 
+app.post("/api/account/password", (req, res) => {
+  const sessionId = getSessionIdFromRequest(req);
+  const account = sessionId ? db.getAccountBySession(sessionId) : null;
+  if (!account) return res.status(401).json({ error: "not logged in" });
+  const { currentPassword, newPassword } = req.body || {};
+  if (!currentPassword || !newPassword) {
+    return res.status(400).json({ error: "current and new password required" });
+  }
+  if (!verifyPassword(currentPassword, account.password_hash)) {
+    return res.status(400).json({ error: "incorrect password" });
+  }
+  const hash = hashPassword(newPassword);
+  db.setAccountPassword(account.id, hash);
+  res.json({ success: true });
+});
+
 app.post("/api/logout", (req, res) => {
   console.debug("[Server Debug] POST /api/logout");
   try {

--- a/Aurora/src/taskDb.js
+++ b/Aurora/src/taskDb.js
@@ -1055,6 +1055,10 @@ export default class TaskDB {
     this.db.prepare('UPDATE accounts SET timezone=? WHERE id=?').run(timezone, id);
   }
 
+  setAccountPassword(id, passwordHash) {
+    this.db.prepare('UPDATE accounts SET password_hash=? WHERE id=?').run(passwordHash, id);
+  }
+
   getAccountBySession(sessionId) {
     return this.db.prepare('SELECT * FROM accounts WHERE session_id=?').get(sessionId);
   }


### PR DESCRIPTION
## Summary
- add Change Password form in Account modal
- allow user to change password from UI
- support password update in DB and server

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684556f49d248323a2999e012704b423